### PR TITLE
Basic setup.py, to be able to do "python setup.py develop".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='pylearn2',
+    version='0.1dev',
+    packages=find_packages(),
+    description='A machine learning library build on top of Theano.',
+    license='BSD 3-clause license',
+    long_description=open('README.rst').read(),
+)


### PR DESCRIPTION
This is the start of a setup.py file. It allows at least doing "python setup.py develop", for development using virtualenvs. The "sdist" command also works reasonably well. I've also specified the license and long description.
