### PR TITLE
Error in assert makes build_stacked_RBM uncallable with vis_type='gaussian'

### DIFF
--- a/pylearn2/models/rbm.py
+++ b/pylearn2/models/rbm.py
@@ -1054,7 +1054,7 @@ def build_stacked_RBM(nvis, nhids, batch_size, vis_type='binary',
     if vis_type == 'binary':
         assert input_mean_vis is None
     elif vis_type == 'gaussian':
-        assert input_mean_vis in True, False
+        assert input_mean_vis in (True, False)
 
     # The number of visible units in each layer is the initial input
     # size and the first k-1 hidden unit sizes.


### PR DESCRIPTION
In

```
assert input_mean_vis in (True, False)
```

the parentheses are needed, otherwise gives error

```
TypeError: argument of type 'bool' is not iterable
```
