### PR TITLE
Supervised CrossEntropy cost correction and new classifier layer

### DIFF
--- a/pylearn2/classifier.py
+++ b/pylearn2/classifier.py
@@ -89,3 +89,154 @@ class LogisticRegressionLayer(Block, Model):
     def __call__(self, inp):
         """TODO: docstring"""
         return self.p_y_given_x(inp)
+
+class CumulativeProbabilitiesLayer(LogisticRegressionLayer):
+    """
+    A layer whose output is seen as a discrete cumulative distribution
+    function, i.e. unit i outputs p(y <= i | x).
+
+    To ensure that the outputs are in ascending order, the weights
+    matrix is shared between all units and the bias b_i are transformed
+    into
+            c_i = c_{i-1} + softplus(b_i), c_0 = b_0,
+    so that they are in ascending order.
+
+    The outputs are used to compute p_y_given_x as
+            p(y = i | x) = p(y <= i | x) - p(y <= i - 1 | x)
+
+                             |  output_i - output_{i-1}, i > 0
+                         =  -+
+                             |  output_i               , i = 0
+
+    In the special case where some units are saturated, some
+    p(y = i | x) = 0 may appear, which can cause problem with regular
+    negative log likelihood. It is recommended that the cost function used
+    for this layer relies instead on p(y <= i | x), such as
+    cost = -sum_over_i(indicator(y <= i) * log(p(y <= i | x)) +
+                       indicator(y > i) * log(1 - p(y <= i | x)))
+    """
+
+    def __init__(self, nvis, nclasses):
+        """
+        Initialize the parameters, with W being shared between all units.
+
+        :type nvis: int
+        :param nvis: number of input units, the dimension of the space in
+                     which the datapoints lie.
+
+        :type nclasses: int
+        :param nclasses: number of output units, the dimension of the space
+                         in which the labels lie.
+        """
+        super(CumulativeProbabilitiesLayer, self).__init__(nvis, nclasses)
+
+        self.W = sharedX(numpy.zeros((nvis, 1)), name='W', borrow=True)
+
+
+    def p_y_ie_n(self, inp):
+        """
+        Computes the p(y <= i | x) vector given an input.
+
+        The implementation of this function relies on transformation
+        matrices, which are explained within the code.
+
+        :type inp: theano.tensor.TensorType
+        :param inp: the input used to compute p_y_ie_n
+        """
+        # As explained in the class docstring, to ensure that the outputs
+        # are in ascending order, the W weights matrix is shared between
+        # units and the bias vector is transformed so its elements are in
+        # ascending order. We use
+        #
+        #  c_0 = b_0
+        #  c_i = c_{i-1} + softplus(b_i)
+        #      = c_{i-2} + softplus(b_{i-1}) + softplus(b_i)
+        #      = ... = c_0 + softplus(b_1) + ... + softplus(b_i)
+        #
+        # which can be represented as
+        #
+        # | c_0 |   | 1 0 ... 0 |   | b_0 |   | 0 0 0 ... 0 |           | b_0 |
+        # | c_1 | = | 1 0 ... 0 | * | b_1 | + | 0 1 0 ... 0 | * softplus| b_1 |
+        # | ... |   |     ...   |   | ... |   |     ...     |           | ... |
+        # | c_n |   | 1 0 ... 0 |   | b_n |   | 0 1 1 ... 1 |           | b_n |
+        #
+        # or
+        #
+        # C = K_1 * B + K_2 * softplus(B) 
+        #
+        # Here we generate K_1. Since B is a 1-dimension vector, we must
+        # transpose K_1 to make it work.
+        k1_val = numpy.zeros((self.nclasses, self.nclasses),
+                             dtype=theano.config.floatX)
+        k1_val[:, 0] = 1.0
+        k1_val = numpy.transpose(k1_val)
+        k1 = theano.shared(value=k1_val, name='k1')
+        # Here we generate K_2, which is transposed for the same reason.
+        # We first create a (nclasses - 1) x (nclasses - 1) lower triangular
+        # matrix and then append the necessary left and upper zeros.
+        k2_val = numpy.ones((self.nclasses - 1, self.nclasses - 1),
+                            dtype=theano.config.floatX)
+        for i in xrange(self.nclasses - 1):
+            for j in xrange(self.nclasses - 1):
+                if(j > i):
+                    k2_val[i, j] = 0
+        k2_val = numpy.append(numpy.zeros((self.nclasses - 1, 1),
+                                          dtype=theano.config.floatX),
+                              k2_val, axis=1)
+        k2_val = numpy.append(numpy.zeros((1, self.nclasses),
+                                          dtype=theano.config.floatX),
+                              k2_val, axis=0)
+        k2_val = numpy.transpose(k2_val)
+        k2 = theano.shared(value=k2_val, name='k2')
+
+        # The K_1 * B term
+        b0_term = T.dot(self.b, k1)
+
+        # The K_2 * softplus(B) term
+        softplus_term = T.dot(T.nnet.softplus(self.b), k2)
+
+        # The constructed bias that is ensured to be in ascending order
+        c = b0_term + softplus_term
+
+        # Since W is a columns vector, we need to expand it into a matrix.
+        weights_constructor_val = numpy.ones((1, self.nclasses))
+        weights_constructor = theano.shared(value=weights_constructor_val,
+                                            name='weights_constructor')
+        weights_matrix = T.dot(self.W,  weights_constructor)
+
+        # Compute p(y <= i | x)
+        return T.nnet.sigmoid(T.dot(self.input, weights_matrix) + c)
+
+    def p_y_given_x(self, inp):
+        """
+        Computes p(y = i | x) as p(y <= i | x) - p(y <= i - 1 | x).
+
+        As mentionned in the p_y_ie_n function, the cost function should
+        not rely on p_y_given_x because of the zero probabilities that can
+        arise if the output units are saturated. It is instead recommended
+        to use p_y_ie_n in the cost function expression.
+
+        :type inp: theano.tensor.TensorType
+        :param inp: the input used to compute p_y_given_x
+        """
+        # The expression for p(y = i | x) can be represented in matricial
+        # form as
+        #
+        # P = A * P_prime, P = p(y = i | x), P_prime = p(y <= i | x),
+        #                  A = |  1  0  0  0  ...  0  0  |
+        #                      | -1  1  0  0  ...  0  0  |
+        #                      |  0 -1  1  0  ...  0  0  |
+        #                      |          ...      0  0  |
+        #                      |  0  0  0  0  ... -1  1  |
+        #
+        # Here we compute A_transposed because p_y_given_x is a 1-dimension
+        # vector.
+        a = numpy.eye(self.nclasses, dtype=theano.config.floatX)
+        for i in xrange(self.nclasses):
+            if(i > 0):
+                a[i - 1, i] = -1
+
+        p_y_given_x_mat = theano.shared(value=a, name='p_y_given_x_mat')
+
+        # Compute p_y_given_x
+        return T.dot(self.p_y_ie_n(inp), p_y_given_x_mat)

--- a/pylearn2/costs/supervised_cost.py
+++ b/pylearn2/costs/supervised_cost.py
@@ -6,4 +6,4 @@ from pylearn2.costs.cost import SupervisedCost
 class CrossEntropy(SupervisedCost):
     def __call__(self, model, X, Y):
         return (-Y * T.log(model(X)) - \
-                (1 - Y) * T.log(model(X))).sum(axis=1).mean()
+                (1 - Y) * T.log(1 - model(X))).sum(axis=1).mean()


### PR DESCRIPTION
I think the pylearn2.costs.supervised_cost.CrossEntropy has an error in it and I have corrected it. 

I also added a class in pylearn2.classification representing a layer which can be seen as computing the discrete cumulative distribution function for an ordered set of classes. Yoshua asked me to experiment with it.
