### PR TITLE
Fix failing test that constructed a shared variable from a tensorConstant

### DIFF
--- a/pylearn2/optimization/minres.py
+++ b/pylearn2/optimization/minres.py
@@ -109,7 +109,6 @@ def minres(compute_Av,
     eps = constantX(1e-23)
 
     # Initialise
-    flag = theano.shared(constantX(0.))
     beta1 = sqrt_inner_product(bs)
 
     #------------------------------------------------------------------


### PR DESCRIPTION
This is not supported anymore as this create a generic and when people do this, it was a mistake. Also this shared variable wasn't used, so I just remove it.
