### PR TITLE
Fix contractive autoencoder penalty

### DIFF
--- a/pylearn2/autoencoder.py
+++ b/pylearn2/autoencoder.py
@@ -483,7 +483,7 @@ class ContractiveAutoencoder(Autoencoder):
             SquaredError, to penalize it.
         """
         act_grad = self._activation_grad(inputs)
-        frob_norm = tensor.dot(tensor.sqr(act_grad), tensor.sqr(self.weights.sum(axis=0)))
+        frob_norm = tensor.dot(tensor.sqr(act_grad), tensor.sqr(self.weights).sum(axis=0))
         contract_penalty = frob_norm.sum() / inputs.shape[0]
         return contract_penalty
 


### PR DESCRIPTION
I believe there is a small bug in the computation of the penalty for the contractive autoencoder. It looks like a parenthesis was misplaced and the weights matrix is summed then squared instead of the other way around.
