### PR TITLE
Minor fix in SGDOptimizer.learning_rates_setup

### DIFF
--- a/pylearn2/optimizer.py
+++ b/pylearn2/optimizer.py
@@ -138,7 +138,7 @@ class SGDOptimizer(Optimizer):
                         'at least two parameters have the same name. '
                         'Both will be affected by the keyword argument '
                         '%s.' % lr_name)
-            lr_names_seen.add(parameter.name)
+            lr_names_seen.add(lr_name)
 
             thislr = kwargs.get(lr_name, 1.)
             self.learning_rates[parameter] = sharedX(thislr, lr_name)


### PR DESCRIPTION
only a minor fix in 
SGDOptimizer.learning_rates_setup()

I was getting a warning

``` bash
"Warning: in SGDOptimizer, keyword argument w_z_in_lr will be ignored, because no parameter was found with name w_z_in." 
```

although the provided parameter list contained a shared variable with name 'w_z_in' and self.learning_rates was updated accordingly (set to the specified value, which was not the default 1.0).
