### PR TITLE
Add mlp.PretrainedLayer

### DIFF
--- a/pylearn2/models/autoencoder.py
+++ b/pylearn2/models/autoencoder.py
@@ -233,6 +233,13 @@ class Autoencoder(Block, Model):
         """
         return self.hidbias + tensor.dot(x, self.weights)
 
+    def upward_pass(self, inputs):
+        """
+        Wrapper to Autoencoder encode function. Called when autoencoder
+        is accessed by mlp.PretrainedLayer
+        """
+        return self.encode(inputs)
+
     def encode(self, inputs):
         """
         Map inputs through the encoder function.

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -2210,12 +2210,12 @@ def beta_from_features(dataset, **kwargs):
 def mean_of_targets(dataset):
     return dataset.y.mean(axis=0)
 
-class RBM_Layer(Layer):
+class PretrainedLayer(Layer):
     """
-    An MLP layer whose forward prop is an upward mean field pass through an RBM
+    A layer whose weights are fixed based on prior training. 
     """
 
-    def __init__(self, layer_name, rbm, freeze_params=False):
+    def __init__(self, layer_name, layer_content, freeze_params=False):
         self.__dict__.update(locals())
         del self.self
 
@@ -2225,16 +2225,23 @@ class RBM_Layer(Layer):
     def get_params(self):
         if self.freeze_params:
             return []
-        return self.rbm.get_params()
+        return self.layer_content.get_params()
 
     def get_input_space(self):
-        return self.rbm.get_input_space()
+        return self.layer_content.get_input_space()
 
     def get_output_space(self):
-        return self.rbm.get_output_space()
+        return self.layer_content.get_output_space()
 
     def fprop(self, state_below):
+        return self.layer_content.upward_pass(state_below)
 
-        return self.rbm.mean_h_given_v(state_below)
+class RBM_Layer(PretrainedLayer):
+    """An MLP layer whose forward prop is an upward mean field pass through an RBM.
+    Deprecated in favor of direct call to PretrainedLayer.
+    """
 
-
+    def __init__(self, layer_name, autoencoder, freeze_params=False):
+        warnings.warn("RBM_Layer is deprecated. Use PretrainedLayer instead. RBM_Layer will be removed on or after October 19, 2013", stacklevel=2)
+        PretrainedLayer.__init__(layer_name=layer_name, layer_content=autoencoder, 
+                                    freeze_params=freeze_params)

--- a/pylearn2/models/rbm.py
+++ b/pylearn2/models/rbm.py
@@ -601,6 +601,13 @@ class RBM(Block, Model):
         else:
             return [self.input_to_v_from_h(hid) for hid in h]
 
+    def upward_pass(self, v):
+        """
+        wrapper around mean_h_given_v method.  Called when RBM is accessed
+        by mlp.HiddenLayer.
+        """
+        return self.mean_h_given_v(v)
+
     def mean_h_given_v(self, v):
         """
         Compute the mean activation of the hidden units given visible unit


### PR DESCRIPTION
Added mlp.PretrainedLayer as more general alternative to mlp.RBM_Layer.
 Also added upward pass methods to RBM and Autoencoder classes to be
called by PretrainedLayer.
