### PR TITLE
Added get_decay methods to Pretrained Layer to allow use in MLP's with decay in cost

### DIFF
--- a/pylearn2/costs/mlp/__init__.py
+++ b/pylearn2/costs/mlp/__init__.py
@@ -46,7 +46,7 @@ class WeightDecay(Cost):
                 if coef==0.:
                     return 0.
                 else:
-                    raise NotImplementedError("TODO: add uniform weight decay inference to unsupervised models.")
+                    raise NotImplementedError(str(type(layer))+" does not implement get_weight_decay.")
 
 
         layer_costs = [ wrapped_layer_cost(layer, coeff)

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -134,6 +134,13 @@ class Layer(Model):
         """
         raise NotImplementedError(str(type(self))+" does not implement mlp.Layer.cost_matrix")
 
+    def get_weight_decay(self, coeff):
+        raise NotImplementedError
+    
+    def get_l1_weight_decay(self, coeff):
+        raise NotImplementedError
+
+
 class MLP(Layer):
     """
     A multilayer perceptron.
@@ -2243,11 +2250,6 @@ class PretrainedLayer(Layer):
     def fprop(self, state_below):
         return self.layer_content.upward_pass(state_below)
 
-    def get_weight_decay(self, coeff):
-        raise NotImplementedError
-    
-    def get_l1_weight_decay(self, coeff):
-        raise NotImplementedError
 
 
 class RBM_Layer(PretrainedLayer):


### PR DESCRIPTION
Added get_weight_decay and get_l1_weight_decay methods to
PretrainedLayer class.  Both methods return 0

An alternative behavior would calculate a decay for these layers, but
it would be fixed in each iteration of the MLP.
