### PR TITLE
Transfer the output gradient of GPU ops back to GPU

### DIFF
--- a/pylearn2/sandbox/cuda_convnet/img_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/img_acts.py
@@ -44,6 +44,7 @@ The copyright and licensing notice for this code is reproduced below:
 from theano.gradient import DisconnectedType
 from theano.gof import Apply
 from theano.sandbox.cuda import CudaNdarrayType
+from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
 
 from pylearn2.sandbox.cuda_convnet.base_acts import BaseActs
 from pylearn2.sandbox.cuda_convnet.base_acts import UnimplementedError
@@ -130,6 +131,7 @@ class ImageActs(BaseActs):
     def grad(self, inputs, g_outputs):
         hid_acts, filters, output_shape = inputs
         g_images, = g_outputs
+        g_images = as_cuda_ndarray_variable(g_images)
         assert not isinstance(g_images, list)
 
         global FilterActs

--- a/pylearn2/sandbox/cuda_convnet/response_norm.py
+++ b/pylearn2/sandbox/cuda_convnet/response_norm.py
@@ -47,6 +47,7 @@ The copyright and licensing notice for this code is reproduced below:
 
 import theano
 from theano.sandbox.cuda import CudaNdarrayType
+from theano.sandbox.cuda.basic_ops import as_cuda_ndarray_variable
 from theano.gof import Apply, local_optimizer, TopoOptimizer
 from pylearn2.sandbox.cuda_convnet.base_acts import BaseActs
 from .code_templates import (
@@ -191,6 +192,7 @@ class CrossMapNorm(BaseActs):
         images, = inputs
         acts, denoms = self(images)
         dout, _ = dout  # Ignore the gradient on "denoms"
+        dout = as_cuda_ndarray_variable(dout)
         grad_op = CrossMapNormUndo(self._size_f, self._add_scale,
                                    self._pow_scale, self._blocked,
                                    inplace=False)


### PR DESCRIPTION
This was not needed for the other ops in cuda_convnet, because
they were already calling gpu_contiguous.
