### PR TITLE
Trivial syntax error fix in NoDataPathError

### DIFF
--- a/pylearn2/datasets/exc.py
+++ b/pylearn2/datasets/exc.py
@@ -11,7 +11,7 @@ class NoDataPathError(EnvironmentVariableError):
     defined.
     """
     def __init__(self):
-        super(NoDataPathError, self)(data_path_essay)
+        super(NoDataPathError, self).__init__(data_path_essay)
 
 data_path_essay = """\
 You need to define your PYLEARN2_DATA_PATH environment variable. If you are


### PR DESCRIPTION
When a dataset is not found when loading from a .yaml, pylearn tries to raise a NoDataPathError, but that exception's **init** has a syntax error which means a TypeError gets raised instead.
