### PR TITLE
Bug fix: casting problem in OneHotFormatter

### DIFF
--- a/pylearn2/format/target_format.py
+++ b/pylearn2/format/target_format.py
@@ -63,6 +63,7 @@ class OneHotFormatter(object):
         row_offsets = tensor.arange(0, self._max_labels * targets.shape[0],
                                     self._max_labels)
         indices = row_offsets + targets
-        one_hot_flat = tensor.set_subtensor(one_hot_flat[indices], 1)
+        one_hot_flat = tensor.set_subtensor(one_hot_flat[indices],
+                                            numpy.cast[self._dtype](1))
         return one_hot_flat.reshape((targets.shape[0],
                                      tensor.constant(self._max_labels)))


### PR DESCRIPTION
It was causing the optimization fail on gpu because lack of support for int8 on gpu
