### PR TITLE
Fix name of preprocessor constant so header is not hidden

### DIFF
--- a/pylearn2/sandbox/cuda_convnet/pool_rop.cuh
+++ b/pylearn2/sandbox/cuda_convnet/pool_rop.cuh
@@ -21,8 +21,8 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef CONV_UTIL_CUH
-#define	CONV_UTIL_CUH
+#ifndef POOL_ROP_CUH
+#define POOL_ROP_CUH
 
 #include <nvmatrix.cuh>
 #include <conv_util.cuh>
@@ -572,5 +572,5 @@ void convLocalPoolR(NVMatrix& images,
     cutilCheckMsg("convLocalPool: kernel execution failed");
 }
 
-#endif	/* CONV_UTIL_CUH */
+#endif /* POOL_ROP_CUH */
 


### PR DESCRIPTION
This should fix some recent failures in the nightly buildbot.
