### PR TITLE
Refactor Conv2DSpace -> Conv{N,2,3}DSpace

### DIFF
--- a/pylearn2/space/tests/test_space.py
+++ b/pylearn2/space/tests/test_space.py
@@ -6,7 +6,7 @@ from theano import config
 from theano import tensor
 from theano.sandbox.cuda import CudaNdarrayType
 
-from pylearn2.space import Conv2DSpace
+from pylearn2.space import ConvNDSpace, Conv2DSpace, Conv3DSpace
 from pylearn2.space import CompositeSpace
 from pylearn2.space import VectorSpace
 from pylearn2.space import Space
@@ -126,3 +126,20 @@ def test_broadcastable():
     d = Conv2DSpace((5, 5), channels=3,
                     axes=['b', 0, 1, 'c']).make_theano_batch(batch_size=1)
     np.testing.assert_(d.broadcastable[0])
+
+
+def test_no_abstract_ConvNDSpace_creation():
+    try:
+        convNDSpace = ConvNDSpace((1,1), channels = 1) # should fail
+    except AssertionError:
+        pass
+    else:
+        raise Exception('Instantiation of abstract base class ConvNDSpace should have failed but it suceeded.')
+
+
+def test_Conv2DSpace_creation():
+    c = Conv2DSpace((1,1), channels = 1)
+
+
+def test_Conv3DSpace_creation():
+    c = Conv3DSpace((1,1,1), channels = 1)


### PR DESCRIPTION
Pylearn2 currently uses the Conv2DSpace object to represent a batch of potentially multi-channel images in a 4D tensor. I'd like to represent a batch of potentially multi-channel video segments in a 5D tensor. To this end I figured we would need a Conv3DSpace, so I refactored Conv2DSpace into a base ConvNDSpace class with two derived classes, Conv2DSpace and Conv3DSpace. I aimed to keep the public interface of the derived Conv2DSpace class identical to the original interface.

I ran nosetests on both the upstream/master and on my branch and got exactly the same results (two seemingly unrelated errors):

```
/home/jason/s/upstream-pylearn2/pylearn2/models/dbm/__init__.py:48: UserWarning: DBM changing the recursion limit.
  warnings.warn("DBM changing the recursion limit.")
/home/jason/s/upstream-pylearn2/pylearn2/packaged_dependencies/theano_linear/test_matrixmul.py:62: UserWarning: TODO: port these disabled tests to the new pylearn2 setup
  warnings.warn("TODO: port these disabled tests to the new pylearn2 setup")
/home/jason/s/upstream-pylearn2/pylearn2/models/mlp.py:41: UserWarning: MLP changing the recursion limit.
  warnings.warn("MLP changing the recursion limit.")
........./home/jason/s/upstream-pylearn2/pylearn2/datasets/tests/test_dense_design_matrix.py:63: UserWarning: Overloading this method is not necessary with the new interface change and this will be removed around November 7th 2013
  it = ds.iterator(mode = 'sequential', batch_size = 1)
.......F...../home/jason/s/upstream-pylearn2/pylearn2/devtools/tests/test_record.py:9: UserWarning: These tests should be moved to theano.
  warnings.warn("These tests should be moved to theano.")
............../home/jason/s/upstream-pylearn2/pylearn2/expr/tests/test_normalize.py:70: UserWarning: TODO: add test for the CudaConvnet version.
  warnings.warn("TODO: add test for the CudaConvnet version.")
......../home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/theano/sandbox/rng_mrg.py:756: UserWarning: MRG_RandomStreams Can't determine #streams from size (Elemwise{Cast{int32}}.0), guessing 60*256
  nstreams = self.n_streams(size)
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28288197517 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
../home/jason/s/upstream-pylearn2/pylearn2/expr/tests/test_probabilistic_max_pooling.py:233: UserWarning: TODO: make sampling tests run on c01b format of pooling.
  warnings.warn("TODO: make sampling tests run on c01b format of pooling.")
...................................../home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/theano/sandbox/rng_mrg.py:756: UserWarning: MRG_RandomStreams Can't determine #streams from size (Shape.0), guessing 60*256
  nstreams = self.n_streams(size)
./home/jason/s/upstream-pylearn2/pylearn2/training_algorithms/sgd.py:108: UserWarning: init_momentum interface is deprecated and will become officially unsuported as of May 9, 2014. Please use the `learning_rule` parameter instead, providing an object of type `pylearn2.training_algorithms.learning_rule.Momentum` instead
  warnings.warn("init_momentum interface is deprecated and will "
..../home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26474499702 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26676392555 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26841211319 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
./home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.27088499069 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26497602463 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.27068591118 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.27760004997 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.2773630619 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.27830815315 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
./home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28410291672 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.278028965 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
./home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26933002472 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28106307983 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.27511906624 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28001594543 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28605985641 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.27609086037 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28796505928 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28825688362 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:513: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.28167486191 in a call to theano_rng.multinomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.multinomial.")
...../home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.2679438591 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
./home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26441597939 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.25694704056 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26880598068 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/expr/probabilistic_max_pooling.py:416: UserWarning: TODO: speed up theano's random number seeding. max pooling spent 2.26821994781 in a call to theano_rng.binomial.
  warnings.warn("TODO: speed up theano's random number seeding. max pooling spent "+str(t2-t1)+" in a call to theano_rng.binomial.")
/home/jason/s/upstream-pylearn2/pylearn2/costs/dbm.py:157: UserWarning: TODO: reduce variance of negative phase by
                         integrating out the even-numbered layers. The
                         Rao-Blackwellize method can do this for you when
                         expected gradient = gradient of expectation, but
                         doing this in general is trickier.
  doing this in general is trickier.""")
../home/jason/s/upstream-pylearn2/pylearn2/models/dense_binary_dbm.py:33: UserWarning: s3c changing the recursion limit
  warnings.warn('s3c changing the recursion limit')
/home/jason/s/upstream-pylearn2/pylearn2/models/s3c.py:24: UserWarning: s3c changing the recursion limit
  warnings.warn('s3c changing the recursion limit')
/home/jason/s/upstream-pylearn2/pylearn2/models/dense_binary_dbm.py:108: UserWarning: dense_binary_dbm is deprecated and no longer under development. It is mostly needed as a component of a larger model that remains private, and will be removed after the larger model has been refactored to use the new pylearn2.models.dbm. Contact Ian Goodfellow if you have questions about this class.
  warnings.warn("dense_binary_dbm is deprecated and no longer under "
./home/jason/s/upstream-pylearn2/pylearn2/models/tests/test_dropout.py:17: UserWarning: 
TODO: add test that dropout_fprop with all include probabilities and scales set
    to 1 is equivalent to fprop.
TODO: add a test file to the corresponding cost module and make sure that the
    dropout cost with everything set to 1 is equivalent to the Default cost

  """)
Using gpu device 0: GeForce GTX 560 Ti
/home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/pool.py:26: UserWarning: image_shape argument isn't needed anymore, quit passing it.
  warnings.warn("image_shape argument isn't needed anymore, quit passing it.")
/home/jason/s/upstream-pylearn2/pylearn2/training_algorithms/sgd.py:638: UserWarning: sgd.MomentumAdjustor interface is deprecated and will become officially unsuported as of May 9, 2014. Please use `learning_rule.MomentumAdjustor` instead.
  warnings.warn("sgd.MomentumAdjustor interface is deprecated and will "
/home/jason/s/upstream-pylearn2/pylearn2/models/mlp.py:386: UserWarning: dropout doesn't use fixed_var_descr so it won't work with algorithms that make more than one theano function call per batch, such as BGD. Implementing fixed_var descr could increase the memory usage though.
  warnings.warn("dropout doesn't use fixed_var_descr so it won't work with "
/home/jason/s/upstream-pylearn2/pylearn2/datasets/dense_design_matrix.py:1041: UserWarning: It looks like DefaultViewConverter.axes has been changed directly, please use the set_axes() method instead.
  "instead." % self.__class__.__name__)
..............................S............................................................................/home/jason/s/upstream-pylearn2/pylearn2/optimization/test_linesearch.py:139: UserWarning: Theano is broken; this test causes an optimization failure. Skipping the test so as not to break the pylearn2 buildbot.
  warnings.warn("Theano is broken; this test causes an optimization"
.................................................................../home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts.py:65: UserWarning: test_match_valid_conv success criterion is not very strict. Can we verify that this is OK?
                     One possibility is that theano is numerically unstable and Alex's code is better.
                     Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
./home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts.py:123: UserWarning: test_match_valid_conv success criterion is not very strict. Can we verify that this is OK?
                     One possibility is that theano is numerically unstable and Alex's code is better.
                     Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
./home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts.py:186: UserWarning: test_match_valid_conv success criterion is not very strict. Can we verify that this is OK?
                     One possibility is that theano is numerically unstable and Alex's code is better.
                     Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
./home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts.py:253: UserWarning: test_match_valid_conv success criterion is not very strict. Can we verify that this is OK?
                     One possibility is that theano is numerically unstable and Alex's code is better.
                     Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
F/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/theano/sandbox/rng_mrg.py:756: UserWarning: MRG_RandomStreams Can't determine #streams from size ((Elemwise{add,no_inplace}.0,)), guessing 60*256
  nstreams = self.n_streams(size)
/home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts.py:343: UserWarning: test_match_valid_conv success criterion is not very strict. Can we verify that this is OK?
                     One possibility is that theano is numerically unstable and Alex's code is better.
                     Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
./home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_img_acts.py:76: UserWarning: test_match_full_conv success criterion is not very strict. Can we verify that this is OK?
                     One possibility is that theano is numerically unstable and Alex's code is better.
                     Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
.../home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/probabilistic_max_pooling.py:113: UserWarning: non square pool shape and strides different than pool shape hasn't been tested and disabled
  warnings.warn("non square pool shape and strides different than "
......./home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_rop_pool.py:44: UserWarning: TODO: Razvan needs to finish this
  warnings.warn("TODO: Razvan needs to finish this")
.../home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_weight_acts.py:98: UserWarning: test_match_grad_valid_conv success criterion is not very strict. Can we verify that this is OK?
                         One possibility is that theano is numerically unstable and Alex's code is better.
                         Probably theano CPU 64 bit is OK but it's worth checking the others.
  Probably theano CPU 64 bit is OK but it's worth checking the others.""")
.E/home/jason/s/upstream-pylearn2/pylearn2/train.py:87: UserWarning: dataset has no yaml src, model won't know what data it was trained on
  warnings.warn("dataset has no yaml src, model won't know what data it was trained on")
/home/jason/s/upstream-pylearn2/pylearn2/monitor.py:475: UserWarning: Trained model saved without indicating yaml_src
  warnings.warn('Trained model saved without indicating yaml_src')
.E........................................................................................../home/jason/s/upstream-pylearn2/pylearn2/scripts/dbm/dbm_metrics.py:545: UserWarning: This is garanteed to work only for DBMs with a BinaryVector visible layer and BinaryVectorMaxPool hidden layers with pool sizes of 1.
  "hidden layers with pool sizes of 1.")
................/home/jason/s/upstream-pylearn2/pylearn2/tests/test_monitor.py:242: UserWarning: TODO: add unit test that iterators uneven property is set correctly.
  warnings.warn("TODO: add unit test that iterators uneven property is set correctly.")
............
======================================================================
ERROR: Failure: ImportError (No module named jobman.tools)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/nose/loader.py", line 413, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/jason/s/upstream-pylearn2/pylearn2/scripts/jobman/tester.py", line 15, in <module>
    from jobman.tools import DD, flatten
ImportError: No module named jobman.tools

======================================================================
ERROR: tests that the grbm_smd example script runs correctly
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/jason/s/upstream-pylearn2/pylearn2/testing/__init__.py", line 29, in wrapped
    return fn(*args, **kwargs)
  File "/home/jason/s/upstream-pylearn2/pylearn2/scripts/tutorials/grbm_smd/test_grbm_smd.py", line 20, in test_train_example
    train_object = load_train_file(train_yaml_path)
  File "/home/jason/s/upstream-pylearn2/pylearn2/utils/serial.py", line 435, in load_train_file
    return yaml_parse.load_path(config_file_path)
  File "/home/jason/s/upstream-pylearn2/pylearn2/config/yaml_parse.py", line 87, in load_path
    return load(content, **kwargs)
  File "/home/jason/s/upstream-pylearn2/pylearn2/config/yaml_parse.py", line 49, in load
    proxy_graph = yaml.load(processed_string, **kwargs)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/__init__.py", line 71, in load
    return loader.get_single_data()
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/constructor.py", line 39, in get_single_data
    return self.construct_document(node)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/constructor.py", line 43, in construct_document
    data = self.construct_object(node)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/constructor.py", line 90, in construct_object
    data = constructor(self, tag_suffix, node)
  File "/home/jason/s/upstream-pylearn2/pylearn2/config/yaml_parse.py", line 272, in multi_constructor
    mapping = loader.construct_mapping(node)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/constructor.py", line 208, in construct_mapping
    return BaseConstructor.construct_mapping(self, node, deep=deep)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/constructor.py", line 133, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/yaml/constructor.py", line 90, in construct_object
    data = constructor(self, tag_suffix, node)
  File "/home/jason/s/upstream-pylearn2/pylearn2/config/yaml_parse.py", line 295, in multi_constructor_pkl
    rval.instance = serial.load(mapping)
  File "/home/jason/s/upstream-pylearn2/pylearn2/utils/serial.py", line 139, in load
    ". Orig traceback:\n" + tb)
Exception: Couldn't open 'cifar10_preprocessed_train.pkl' due to: <type 'exceptions.IOError'>, [Errno 2] No such file or directory: 'cifar10_preprocessed_train.pkl'. Orig traceback:
Traceback (most recent call last):
  File "/home/jason/s/upstream-pylearn2/pylearn2/utils/serial.py", line 98, in load
    with open(filepath, 'rb') as f:
IOError: [Errno 2] No such file or directory: 'cifar10_preprocessed_train.pkl'


======================================================================
FAIL: Test that passing in the zero vector does not result in
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/jason/s/upstream-pylearn2/pylearn2/datasets/tests/test_preprocessing.py", line 26, in test_zero_vector
    dataset.apply_preprocessor(preprocessor)
  File "/home/jason/s/upstream-pylearn2/pylearn2/datasets/dense_design_matrix.py", line 470, in apply_preprocessor
    preprocessor.apply(self, can_fit)
  File "/home/jason/s/upstream-pylearn2/pylearn2/datasets/preprocessing.py", line 839, in apply
    dataset.set_design_matrix(X)
  File "/home/jason/s/upstream-pylearn2/pylearn2/datasets/dense_design_matrix.py", line 593, in set_design_matrix
    assert not N.any(N.isnan(X))
AssertionError

======================================================================
FAIL: test_filter_acts.test_grad
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jason/virtualenvs/ml/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/jason/s/upstream-pylearn2/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts.py", line 286, in test_grad
    assert False
AssertionError: 
-------------------- >> begin captured stdout << ---------------------
=== FILTERS GRADIENT ===
absolute error range:  (0.0, 1.1444092e-05)
mean absolute error:  1.69546789645e-06
cuda-convnet value range:  (-23.122841, 32.525215)
theano value range:  (-23.122839, 32.525223)

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 414 tests in 934.480s

FAILED (SKIP=1, errors=2, failures=2)
```
