### PR TITLE
Fix possible 0-seeding of MLP Theano RNG

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -390,7 +390,7 @@ class MLP(Layer):
         self._validate_layer_names(list(input_include_probs.keys()))
         self._validate_layer_names(list(input_scales.keys()))
 
-        theano_rng = MRG_RandomStreams(self.rng.randint(2 ** 15))
+        theano_rng = MRG_RandomStreams(max(self.rng.randint(2 ** 15), 1))
 
         for layer in self.layers:
             layer_name = layer.layer_name


### PR DESCRIPTION
This is really a dumb thing that Theano does, and should be fixed there in my opinion, but for the time being I want to preserve behaviour in most cases while fixing the corner case that we have.
