### PR TITLE
Update for changed interface in Theano.

### DIFF
--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/gpu_unshared_conv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/gpu_unshared_conv.py
@@ -285,7 +285,7 @@ class GpuFilterActs(Base):
 
 
 @register_opt()
-@local_optimizer(None)
+@local_optimizer(FilterActs)
 def insert_gpu_filter_acts(node):
     """
     .. todo::
@@ -526,7 +526,7 @@ class GpuWeightActs(Base):
 
 
 @register_opt()
-@local_optimizer(None)
+@local_optimizer(WeightActs)
 def insert_gpu_weight_acts(node):
     """
     .. todo::
@@ -769,7 +769,7 @@ class GpuImgActs(Base):
 
 
 @register_opt()
-@local_optimizer(None)
+@local_optimizer(ImgActs)
 def insert_gpu_img_acts(node):
     """
     .. todo::


### PR DESCRIPTION
The behaviour of @local_optimizer has been changed recently in the Theano master branch.

See: https://github.com/Theano/Theano/commit/b5af34062e5226492e4a9f7ae05c3ebea46c3f84

You can see the effects of this change by installing Theano from github and running train.py on papers/maxout/mnist.yaml 

The latest Theano release (rel-0.6) works fine, so if you plan to depend on released versions then you should ignore this PR.  If pylearn2 should work with the Theano master branch then this change is needed.

There's also a similar line to the changes below at:

./pylearn2/sandbox/cuda_convnet/response_norm.py:374:@local_optimizer([None])

I don't know what the implications of calling @local_optimizer like this are, so I've left it alone, but it may also be effected.
