### PR TITLE
Fix timing

### DIFF
--- a/pylearn2/utils/timing.py
+++ b/pylearn2/utils/timing.py
@@ -49,7 +49,7 @@ def log_timing(logger, task, level=logging.INFO, final_msg=None,
     # delta.total_seconds() only defined in python 2.7
     total_seconds = (delta.microseconds +
                      (delta.seconds + delta.days * 24 * 3600) * 10 ** 6
-                     ) / 10 ** 6
+                     ) / float(10 ** 6)
     if total_seconds < 60:
         delta_str = '%f seconds' % total_seconds
     else:


### PR DESCRIPTION
For durations less than 60 seconds the timing code has been truncating, apparently this traces to a backward compatibility fix that Fred made for Python < 2.7. Simply put, integer division. :(
