### PR TITLE
Deprecate pylearn2.utils.environ.putenv

### DIFF
--- a/pylearn2/scripts/train.py
+++ b/pylearn2/scripts/train.py
@@ -128,7 +128,6 @@ if __name__ == "__main__":
             phase_variable = 'PYLEARN2_TRAIN_PHASE'
             phase_value = 'phase%d' % (number + 1)
             os.environ[phase_variable] = phase_value
-            os.putenv(phase_variable, phase_value)
 
             # Execute this training phase.
             subobj.main_loop()

--- a/pylearn2/utils/environ.py
+++ b/pylearn2/utils/environ.py
@@ -1,22 +1,25 @@
 """
-.. todo::
+    Utilities for working with environment variables.
 
-    WRITEME
-
-    Utilities for working with environment variables
+    DEPRECATED -- This file can be removed.
 """
 import os
+import warnings
 
 def putenv(key, value):
     """
-        Sets environment variables and ensures that the 
-        changes are visible for both the current process
-        and for it's children.
+    DEPRECATED
+
+    Sets environment variables and ensures that the 
+    changes are visible for both the current process
+    and for it's children.
+
+    Use os.environ['VAR'] = 'VALUE' instead; it is exactly equivalent.
     """
+    warnings.warn("pylearn.utils.environ.putenv is deprecated.\n" +
+        "Use os.environ['SOME_VAR'] = 'VALUE'; it is exactly equivalent.\n" +
+        "Avoid os.putenv(..), it will set the environment for childs only.")
 
-    # Make changes visible in this process
+    # Make changes visible in this process and to subprocesses
     os.environ[key] = value
-
-    # Make changes visible to childs forked later
-    os.putenv(key, value)
 

--- a/pylearn2/utils/serial.py
+++ b/pylearn2/utils/serial.py
@@ -15,7 +15,6 @@ from cPickle import BadPickleGet
 io = None
 hdf_reader = None
 import struct
-from pylearn2.utils.environ import putenv
 from pylearn2.utils.string_utils import match
 import shutil
 
@@ -487,14 +486,14 @@ def load_train_file(config_file_path, environ=None):
         config_file_full_stem = config_file_path
 
     for varname in ["PYLEARN2_TRAIN_FILE_FULL_STEM"]:
-        putenv(varname, config_file_full_stem)
+        os.environ[varname] = config_file_full_stem
 
     directory = config_file_path.split('/')[:-1]
     directory = '/'.join(directory)
     if directory != '':
         directory += '/'
-    putenv("PYLEARN2_TRAIN_DIR", directory)
-    putenv("PYLEARN2_TRAIN_BASE_NAME", config_file_path.split('/')[-1] )
-    putenv("PYLEARN2_TRAIN_FILE_STEM", config_file_full_stem.split('/')[-1] )
+    os.environ["PYLEARN2_TRAIN_DIR"] = directory
+    os.environ["PYLEARN2_TRAIN_BASE_NAME"] = config_file_path.split('/')[-1]
+    os.environ["PYLEARN2_TRAIN_FILE_STEM"] = config_file_full_stem.split('/')[-1]
 
     return yaml_parse.load_path(config_file_path, environ=environ)


### PR DESCRIPTION
In contrast to the original comments: changes to os.environ[..] _do_ actually get inherited by child processes.

I replaced all calls to utils.environ.putenv with direct changes to os.environ[..] -- there were only a few.

pylearn2.utils.environ.py could be removed in the future; for now it just prints a deprication warning.
