### PR TITLE
Fixed type checking bug.

### DIFF
--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -550,7 +550,7 @@ class VectorSpace(Space):
         # when it is not available
         if (not self.sparse
                 and not isinstance(batch, np.ndarray)
-                and type(batch) != 'CudaNdarray'):
+                and str(type(batch)) != "<type 'CudaNdarray'>"):
             raise TypeError("The value of a VectorSpace batch should be a "
                             "numpy.ndarray, or CudaNdarray, but is %s."
                             % str(type(batch)))
@@ -795,7 +795,7 @@ class Conv2DSpace(Space):
     @functools.wraps(Space._np_validate)
     def _np_validate(self, batch):
         if (not isinstance(batch, np.ndarray)
-                and type(batch) != 'CudaNdarray'):
+                and str(type(batch)) != "<type 'CudaNdarray'>"):
             raise TypeError("The value of a Conv2DSpace batch should be a "
                             "numpy.ndarray, or CudaNdarray, but is %s."
                             % str(type(batch)))


### PR DESCRIPTION
For a CudaNdarray batch, type(batch) is not equal to the string 'CudaNdarray', so this method of checking type likely never worked. These two lines maybe have been rarely encountered, so this bug probably went unnoticed.

For reference, here is a little poking around in pdb after catching the error in the original code:

```
TypeError: The value of a Conv2DSpace batch should be a numpy.ndarray,
or CudaNdarray, but is <type 'CudaNdarray'>.

ipdb> l
    796     def _np_validate(self, batch):
    797         if (not isinstance(batch, np.ndarray)
    798                 and type(batch) != 'CudaNdarray'):
    799             raise TypeError("The value of a Conv2DSpace batch
should be a "
    800                             "numpy.ndarray, or CudaNdarray, but is %s."
--> 801                             % str(type(batch)))
    802         if batch.ndim != 4:
    803             raise ValueError("The value of a Conv2DSpace batch must be "
    804                              "4D, got %d dimensions for %s." %
    805                              (batch.ndim, batch))
    806

ipdb> type(batch)
<type 'CudaNdarray'>
ipdb> type(type(batch))
<type 'type'>
ipdb> type(batch) == 'CudaNdarray'
False
```
