### PR TITLE
Index space dtypes

### DIFF
--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -761,7 +761,8 @@ class IndexSpace(SimplyTypedSpace):
     def __eq__(self, other):
         return (type(self) == type(other) and
                 self.max_labels == other.max_labels and
-                self.dim == other.dim)
+                self.dim == other.dim and
+                self.dtype == other.dtype)
 
     def __ne__(self, other):
         return (not self == other)

--- a/pylearn2/space/tests/test_space.py
+++ b/pylearn2/space/tests/test_space.py
@@ -26,10 +26,18 @@ def test_np_format_as_vector2vector():
 
 def test_np_format_as_index2index():
     index_space_initial = IndexSpace(max_labels=10, dim=1)
+
     index_space_final = IndexSpace(max_labels=10, dim=1)
     data = np.array([[0], [2], [1], [3], [5], [8], [1]])
     rval = index_space_initial.np_format_as(data, index_space_final)
+    assert index_space_initial == index_space_final
     assert np.all(rval == data)
+
+    index_space_downcast = IndexSpace(max_labels=10, dim=1, dtype='int32')
+    rval = index_space_initial.np_format_as(data, index_space_downcast)
+    assert index_space_initial != index_space_downcast
+    assert np.all(rval == data)
+    assert rval.dtype == 'int32' and data.dtype == 'int64'
 
 
 def test_np_format_as_conv2d2conv2d():


### PR DESCRIPTION
`IndexSpace` represent labels and hence should have an integer `dtype` property. This also allows casting between integer types (e.g. from `int64` to `int32`). The default `dtype` is `int64`, which is also the default for NumPy.
