### PR TITLE
Space unpickling bugfix (backwards-compatibility)

### DIFF
--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -666,7 +666,8 @@ class Space(object):
 
 class SimplyTypedSpace(Space):
     """
-    A space that uses a numpy/theano dtype string for its .dtype property.
+    An abstract base class for Spaces that use a numpy/theano dtype string for
+    its .dtype property.
     """
 
     def __init__(self, dtype='floatX', **kwargs):


### PR DESCRIPTION
We can now unpickle Spaces that were pickled back when Spaces didn't have dtypes (they are given the default dtype, theano.config.floatX).

Also fixed bug in which `IndexSpace.__eq__`, `__str__` weren't using self.dtype.
