### PR TITLE
Minor fix to dbm.layer.BinaryVectorMaxPool

### DIFF
--- a/pylearn2/models/dbm/layer.py
+++ b/pylearn2/models/dbm/layer.py
@@ -901,7 +901,7 @@ class BinaryVectorMaxPool(HiddenLayer):
         W = W.T
 
         W = W.reshape((self.detector_layer_dim, self.input_space.shape[0],
-            self.input_space.shape[1], self.input_space.nchannels))
+            self.input_space.shape[1], self.input_space.num_channels))
 
         W = Conv2DSpace.convert(W, self.input_space.axes, ('b', 0, 1, 'c'))
 


### PR DESCRIPTION
Conv2DSpace.input_space.nchannels deprecated or never existed. Changed to 'num_channels'
