### PR TITLE
6 new cost related functions for ConvRectifiedLinear

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -2614,11 +2614,6 @@ class ConvRectifiedLinear(Layer):
 
         return p
 
-
-    @wraps(Layer.get_default_cost)
-    def get_default_cost(self):
-        return Default()
-
     @wraps(Layer.cost)
     def cost(self, Y, Y_hat):
         return self.cost_from_cost_matrix(self.cost_matrix(Y, Y_hat))
@@ -2630,34 +2625,6 @@ class ConvRectifiedLinear(Layer):
     @wraps(Layer.cost_matrix)
     def cost_matrix(self, Y, Y_hat):
         return T.sqr(Y - Y_hat)
-
-    def cost_from_X(self, data):
-        """
-        Computes self.cost, but takes data=(X, Y) rather than Y_hat as an
-        argument.
-
-        This is just a wrapper around self.cost that computes Y_hat by
-        calling Y_hat = self.fprop(X)
-
-        Parameters
-        ----------
-        data : WRITEME
-        """
-        self.cost_from_X_data_specs()[0].validate(data)
-        X, Y = data
-        Y_hat = self.fprop(X)
-        return self.cost(Y, Y_hat)
-
-    def cost_from_X_data_specs(self):
-        """
-        Returns the data specs needed by cost_from_X.
-
-        This is useful if cost_from_X is used in a MethodCost.
-        """
-        space = CompositeSpace((self.get_input_space(),
-                                self.get_output_space()))
-        source = (self.get_input_source(), self.get_target_source())
-        return (space, source)
 
 
 def max_pool(bc01, pool_shape, pool_stride, image_shape):


### PR DESCRIPTION
I found these useful.  They are copy/pasted from mlp.MLP and mlp.Linear (with the if(self.use_abs_loss) part removed).  
