### PR TITLE
make skip_if_no_gpu more robust

### DIFF
--- a/pylearn2/testing/skip.py
+++ b/pylearn2/testing/skip.py
@@ -39,6 +39,6 @@ def skip_if_no_sklearn():
         raise SkipTest()
 
 def skip_if_no_gpu():
-    if cuda.cuda_available == False:
+    if cuda.cuda_available == False or cuda.cuda_enabled == False:
         raise SkipTest('Optional package cuda disabled.')
 


### PR DESCRIPTION
Seems cuda.cuda_available is only checking for cuda availability. 

```
$ THEANO_FLAGS=device=gpu python -c 'from theano.sandbox import cuda; print cuda.cuda_available'
Using gpu device 2: GeForce GTX 285
True

$ THEANO_FLAGS=device=cpu python -c 'from theano.sandbox import cuda; print cuda.cuda_available'
True
```

But we need skip_if_no_gpu to skip if even if cuda is installed but gpu is not enabled or available. This PR fixes this issue.
