### PR TITLE
Missing prints replaced by logging

### DIFF
--- a/pylearn2/costs/dbm.py
+++ b/pylearn2/costs/dbm.py
@@ -1429,8 +1429,8 @@ class MultiPrediction(DefaultDataSpecsMixin, Cost):
 
                 fake_s = T.dot(below, hack_W) + hack_b
                 if fake_s.ndim != real_grads.ndim:
-                    print fake_s.ndim
-                    print real_grads.ndim
+                    logger.error(fake_s.ndim)
+                    logger.error(real_grads.ndim)
                     assert False
                 sources = [ (fake_s, real_grads) ]
 


### PR DESCRIPTION
Some prints were missed in the previous pull requests.

As we discussed, some print statements have not been modified since they are under comments or use specific print functionality (comma at the end of the print statement). 
