### PR TITLE
Added docstrings to local_c01b_tests

### DIFF
--- a/pylearn2/linear/tests/test_local_c01b.py
+++ b/pylearn2/linear/tests/test_local_c01b.py
@@ -10,6 +10,9 @@ import unittest
 
 
 class TestConv2DC01b(unittest.TestCase):
+    """
+    Test for local receptive fields
+    """
     def setUp(self):
         """
         Set up a test image and filter to re-use


### PR DESCRIPTION
Adds a few missing docstrings; this should make the formatting tests pass.
