### PR TITLE
Fix quirk in `make_symbolic_state` resulting in important slowdowns

### DIFF
--- a/pylearn2/models/dbm/layer.py
+++ b/pylearn2/models/dbm/layer.py
@@ -483,7 +483,8 @@ class BinaryVector(VisibleLayer):
         if self.copies != 1:
             raise NotImplementedError()
         mean = T.nnet.sigmoid(self.bias)
-        rval = theano_rng.binomial(size=(num_examples, self.nvis), p=mean)
+        rval = theano_rng.binomial(size=(num_examples, self.nvis), p=mean,
+                                   dtype=theano.config.floatX)
 
         return rval
 


### PR DESCRIPTION
A call to `theano_rng.binomial` returned an `int64` variable, resulting in some `dot` ops being run on CPU in Python instead of on GPU.
