### PR TITLE
Remove implicit resolvers from yaml_parse

### DIFF
--- a/pylearn2/config/yaml_parse.py
+++ b/pylearn2/config/yaml_parse.py
@@ -317,14 +317,7 @@ def initialize():
     yaml.add_multi_constructor('!import:', multi_constructor_import)
 
     yaml.add_constructor('!import', constructor_import)
-    yaml.add_implicit_resolver(
-        '!import', re.compile(r'(?:[a-zA-Z_][\w_]+\.)+[a-zA-Z_][\w_]+')
-    )
-
     yaml.add_constructor("!float", constructor_float)
-    yaml.add_implicit_resolver(
-        '!float', re.compile(r' [-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?')
-    )
 
     is_initialized = True
 


### PR DESCRIPTION
There's no need to have these implicit resolvers in yaml_parse. Since YAML operates perfectly well without quoting strings, these resolvers simply burden users unnecessarily. For instance, setting `save_path: test.pkl` is currently interpreted as `save_path: !import test.pkl`.
