### PR TITLE
Dropout for other layers than MLPs

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -428,6 +428,7 @@ class MLP(Layer):
             seed = [2013, 1, 4]
 
         self.seed = seed
+        self.theano_rng = None
         self.setup_rng()
 
         assert isinstance(layers, list)


### PR DESCRIPTION
This PR enables to use dropout outside of MLPs.

dropout_fprop is moved to Layer.
That enables FlattenerLayer and CompositeLayer to implement dropout too.
