### PR TITLE
Implements get_weight_decay for WindowLayer.

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -3772,6 +3772,10 @@ class WindowLayer(Layer):
 
         return state_below[extracts]
 
+    @wraps(Layer.get_weight_decay)
+    def get_weight_decay(self, coeffs):
+        return 0
+
     @wraps(Layer.set_input_space)
     def set_input_space(self, space):
         self.input_space = space


### PR DESCRIPTION
If someone uses WindowLayer in its MLP and wants to use weight decay, it gets an error because weight decay isn't implemented for WindowLayer.

This fixes it.
