### PR TITLE
Allow passing None via yaml as kwarg (fixes #855)

### DIFF
--- a/pylearn2/config/tests/test_yaml_parse.py
+++ b/pylearn2/config/tests/test_yaml_parse.py
@@ -117,7 +117,7 @@ def test_multi_constructor_obj():
     try:
         loaded = load("a: !obj:decimal.Decimal { 1 }")
     except TypeError as e:
-        assert str(e) == "received None as the value for the key 1"
+        assert str(e) == "Received non string object (1) as key in mapping."
         pass
     except Exception, e:
         error_msg = "Got the unexpected error: %s" % (e)
@@ -189,6 +189,22 @@ def test_duplicate_keywords_2():
     }"""
 
     loaded = load(yamlfile)
+
+def test_parse_null_as_none():
+    """
+    Tests whether None may be passed via yaml kwarg null.
+    """ 
+    initialize()
+    yamlfile = """{
+             "model": !obj:pylearn2.models.autoencoder.Autoencoder {
+
+                 "nvis" : 1024,
+                 "nhid" : 64,
+                 "act_enc" : Null,
+                 "act_dec" : null
+
+             }
+    }"""
 
 if __name__ == "__main__":
     test_multi_constructor_obj()

--- a/pylearn2/config/yaml_parse.py
+++ b/pylearn2/config/yaml_parse.py
@@ -349,7 +349,7 @@ def multi_constructor_obj(loader, tag_suffix, node):
 
     for key in mapping.keys():
         if not isinstance(key, basestring):
-            message = "Received non string object (%s) as" \
+            message = "Received non string object (%s) as " \
                       "key in mapping." % str(key)
             raise TypeError(message)
 


### PR DESCRIPTION
Fixes #855 where yaml_parse did not allow None as a valid kwarg. Adds a test to ensure None via Null or null in yaml source is a valid kwarg. Also updates test_multi_constructor_obj to reflect unrelated string changes.

Note: I am a novice at using github. If I have done something incorrectly, please let me know!
