### PR TITLE
Implements setter and getter for inv_P and P

### DIFF
--- a/pylearn2/datasets/preprocessing.py
+++ b/pylearn2/datasets/preprocessing.py
@@ -40,6 +40,7 @@ from pylearn2.utils import contains_nan
 
 log = logging.getLogger(__name__)
 
+
 convert_axes = Conv2DSpace.convert_numpy
 
 
@@ -1378,6 +1379,9 @@ class ZCA(Preprocessor):
 
         self.__dict__.update(state)
 
+        if not hasattr(self, "inv_P_"):
+            self.inv_P_ = None
+
     def fit(self, X):
         """
         Fits this `ZCA` instance to a design matrix `X`.
@@ -1481,6 +1485,17 @@ class ZCA(Preprocessor):
             WRITEME
         """
         assert X.ndim == 2
+
+        if self.inv_P_ is None:
+            warnings.warn("inv_P_ was None. Computing "
+                          "inverse of P_ now. This will take "
+                          "some time. For efficiency, it is recommended that "
+                          "in the future you compute the inverse in ZCA.fit() "
+                          "instead, by passing it store_inverse=True.")
+            log.info('inverting...')
+            self.inv_P_ = numpy.linalg.inv(self.P_)
+            log.info('...done inverting')
+
         return self._gpu_matrix_dot(X, self.inv_P_) + self.mean_
 
 

--- a/pylearn2/datasets/zca_dataset.py
+++ b/pylearn2/datasets/zca_dataset.py
@@ -23,9 +23,6 @@ from pylearn2.config import yaml_parse
 from pylearn2.datasets import control
 
 
-logger = logging.getLogger(__name__)
-
-
 class ZCA_Dataset(DenseDesignMatrix):
     """
     A Dataset that was created by ZCA whitening a DenseDesignMatrix.
@@ -104,16 +101,6 @@ class ZCA_Dataset(DenseDesignMatrix):
         if self.X is not None:
             if self.y is not None:
                 assert self.y.shape[0] == self.X.shape[0]
-
-        if getattr(preprocessor, "inv_P_", None) is None:
-            warnings.warn("ZCA preprocessor.inv_P_ was none. Computing "
-                          "inverse of preprocessor.P_ now. This will take "
-                          "some time. For efficiency, it is recommended that "
-                          "in the future you compute the inverse in ZCA.fit() "
-                          "instead, by passing it compute_inverse=True.")
-            logger.info('inverting...')
-            preprocessor.inv_P_ = np.linalg.inv(preprocessor.P_)
-            logger.info('...done inverting')
 
     @wraps(DenseDesignMatrix.has_targets)
     def has_targets(self):


### PR DESCRIPTION
inv_P and P are used in zca_dataset and are accessed
directly. It also makes the assumption that a ZCA object has  
those attributes after initialization, but it's not true for old 
pickled ZCA. 

This pull request adds a getter/setter interface
to access them and also get rids of the assumption that
inv_P_ or P_ is an attribute of t.

It completes a fix made in #833