### PR TITLE
Added a filesize check to local dataset cache

### DIFF
--- a/pylearn2/datasets/cache.py
+++ b/pylearn2/datasets/cache.py
@@ -121,9 +121,9 @@ class LocalDatasetCache:
             log.info("File %s has been locally cached to %s" %
                      (remote_name, local_name))
         elif os.path.getmtime(remote_name) > os.path.getmtime(local_name):
-            log.warning("File %s not cached: The remote file (modified "
-                        "%s) is newer than the locally cached file %s "
-                        "(modified %s)"
+            log.warning("File %s in cache will not be used: The remote file "
+                        "(modified %s) is newer than the locally cached file "
+                        "%s (modified %s)."
                         % (remote_name,
                            time.strftime(
                                '%Y-%m-%d %H:%M:%S',


### PR DESCRIPTION
I ran into the problem where I was experimenting with my own dataset and local caching. When I updated the dataset, the `LocalDatasetCache` just compared filenames and used the outdated locally stored version. This can be pretty tricky to debug, because the model trains just fine, but it's not training on the data that you've given.

I'm just comparing file sizes here, so it's not foolproof, but it doesn't require the file to be hashed or compared byte-wise.
