### PR TITLE
Add support for cuda-convnet's filter groups

### DIFF
--- a/pylearn2/devtools/tests/test_format.py
+++ b/pylearn2/devtools/tests/test_format.py
@@ -438,6 +438,7 @@ whitelist_docstrings = [
     'sandbox/cuda_convnet/tests/test_pool.py',
     'sandbox/cuda_convnet/tests/test_common.py',
     'sandbox/cuda_convnet/tests/test_stochastic_pool.py',
+    "sandbox/cuda_convnet/tests/test_grouped_conv.py",
     'sandbox/cuda_convnet/shared_code.py',
     'sandbox/cuda_convnet/__init__.py',
     'sandbox/cuda_convnet/img_acts.py',

--- a/pylearn2/devtools/tests/test_format.py
+++ b/pylearn2/devtools/tests/test_format.py
@@ -67,6 +67,7 @@ whitelist_pep8 = [
     "sandbox/cuda_convnet/tests/test_img_acts.py",
     "sandbox/cuda_convnet/tests/test_weight_acts.py",
     "sandbox/cuda_convnet/tests/test_stochastic_pool.py",
+    "sandbox/cuda_convnet/tests/test_grouped_conv.py",
     "sandbox/cuda_convnet/specialized_bench.py",
     "sandbox/cuda_convnet/response_norm.py",
     "sandbox/cuda_convnet/__init__.py",

--- a/pylearn2/sandbox/cuda_convnet/base_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/base_acts.py
@@ -84,13 +84,18 @@ class BaseActs(GpuOp):
         self.stride = stride
         self.copy_non_contiguous = 0
         if pattern is not None:
-            groups = len(pattern)
-        self.groups = groups
-        if pattern is not None:
-            pattern = np.array(pattern, dtype=np.int)
+            pattern = np.array(pattern, dtype=np.int)            
+            if groups == 1:
+                groups = len(pattern)
+            elif groups != len(pattern):
+                raise ValueError("The supplied value `groups=%d` does not match "
+                        "the number of groups in the supplied connection pattern "
+                        "(%d). Either omit `groups` or set it to the correct "
+                        "value." % (groups, len(pattern)))
             # TODO: implement in FilterActs/ImageActs/WeightActs.c_code()
             raise NotImplementedError("custom connection patterns not supported yet")
         self.pattern = pattern
+        self.groups = groups
         self.dense_connectivity = (groups == 1) and (pattern is None)  # defined for backwards compatibility, not sure if anybody uses it
 
     def c_header_dirs(self):

--- a/pylearn2/sandbox/cuda_convnet/base_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/base_acts.py
@@ -42,6 +42,7 @@ The copyright and licensing notice for this code is reproduced below:
 """
 
 import warnings
+import numpy as np
 from theano.sandbox.cuda import GpuOp
 from pylearn2.sandbox.cuda_convnet.shared_code import this_dir
 from pylearn2.sandbox.cuda_convnet.convnet_compile import convnet_available
@@ -53,9 +54,25 @@ from theano import config
 
 class BaseActs(GpuOp):
     """
-    Shared code for wrapping various convnet operations.
+    Shared code for wrapping various convnet operations (FilterActs, WeightActs,
+    ImageActs).
+    
+    * pad: Implicitly zero-pad the image with a border of this many pixels
+    * partial_sum: Performance/Memory usage tradeoff. Leave at `None` for lowest
+      memory usage, set to `1` for highest performance, see the [cuda-convnet
+      documentation](http://code.google.com/p/cuda-convnet/wiki/LayerParams#Convolution_layer)
+      for more details.
+    * stride: Distance between successive filter applications in pixels
+    * groups: Divide the input channels and filters into this many groups, apply
+      each filter group to its input channel group only
+    * pattern: Two-dimensional integer numpy array defining which filter group
+      processes which input channels. If `None`, input channels will be
+      divided into `groups` same-sized groups, the first of which will be
+      processed by the first group of filters, the second by the second, etc.
+      If given, must be an array of shape (groups, filter_channels) which for
+      each filter group gives the indices of input channels to be processed.
     """
-    def __init__(self, pad=0, partial_sum=None, stride=1):
+    def __init__(self, pad=0, partial_sum=None, stride=1, groups=1, pattern=None):
 
         if not isinstance(pad, py_integer_types):
             raise TypeError("pad must be an int")
@@ -66,8 +83,15 @@ class BaseActs(GpuOp):
         self.pad = pad
         self.stride = stride
         self.copy_non_contiguous = 0
-        # TODO: support sparse connectivity pattern
-        self.dense_connectivity = True
+        if pattern is not None:
+            groups = len(pattern)
+        self.groups = groups
+        if pattern is not None:
+            pattern = np.array(pattern, dtype=np.int)
+            # TODO: implement in FilterActs/ImageActs/WeightActs.c_code()
+            raise NotImplementedError("custom connection patterns not supported yet")
+        self.pattern = pattern
+        self.dense_connectivity = (groups == 1) and (pattern is None)  # defined for backwards compatibility, not sure if anybody uses it
 
     def c_header_dirs(self):
         return [this_dir, config.pthreads.inc_dir] if config.pthreads.inc_dir else [this_dir]
@@ -117,14 +141,15 @@ class BaseActs(GpuOp):
         return (type(self) == type(other) and
                 self.partial_sum == other.partial_sum and
                 self.pad == other.pad and
-                self.dense_connectivity == other.dense_connectivity and
+                self.groups == other.groups and
+                np.all(self.pattern == other.pattern) and
                 self.stride == other.stride and
                 self.copy_non_contiguous == other.copy_non_contiguous)
 
     def __hash__(self):
         msg = []
         msg.append(self.__class__.__name__)
-        for val in (self.partial_sum, self.pad, self.dense_connectivity,
+        for val in (self.partial_sum, self.pad, self.groups, self.pattern,
                     self.stride, self.copy_non_contiguous):
             msg.append(str(val))
 

--- a/pylearn2/sandbox/cuda_convnet/filter_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/filter_acts.py
@@ -126,7 +126,7 @@ class FilterActs(BaseActs):
 
         * inputs: list of shapes of inputs to this node:
           [(input channels, rows, cols, batch_size),
-           (filter channels, filter rows, filter cols, output channels)]
+          (filter channels, filter rows, filter cols, output channels)]
         * outputs: list of shapes of outputs of this node:
           [(output channels, output rows, output cols, batch size)]
         """

--- a/pylearn2/sandbox/cuda_convnet/img_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/img_acts.py
@@ -191,8 +191,9 @@ class ImageActs(BaseActs):
                 groups=self.groups, pattern=self.pattern)(
                         g_images, hid_acts, filters.shape[1:3])[0]
         assert not isinstance(g_filters, list)
-        g_hid_acts = FilterActs(stride=self.stride, pad=self.pad,
-                partial_sum=self.partial_sum)(g_images, filters)
+        g_hid_acts = FilterActs(stride=self.stride,
+                partial_sum=self.partial_sum, pad=self.pad,
+                groups=self.groups, pattern=self.pattern)(g_images, filters)
 
         return [g_hid_acts, g_filters, DisconnectedType()()]
 

--- a/pylearn2/sandbox/cuda_convnet/img_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/img_acts.py
@@ -146,8 +146,8 @@ class ImageActs(BaseActs):
 
         * inputs: list of shapes of inputs to this node:
           [(output channels, rows, cols, batch size),
-           (filter channels, filter rows, filter cols, output channels),
-           (2,)]
+          (filter channels, filter rows, filter cols, output channels),
+          (2,)]
         * outputs: list of shapes of outputs of this node:
           [(input channels, input rows, input cols, batch size)]
         """

--- a/pylearn2/sandbox/cuda_convnet/tests/test_grouped_conv.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/test_grouped_conv.py
@@ -1,8 +1,8 @@
 __authors__ = "Jan Schlueter"
 __credits__ = ["Jan Schlueter"]
 __license__ = "3-clause BSD"
-__maintainer__ = "Ian Goodfellow"
-__email__ = "goodfeli@iro"
+__maintainer__ = "LISA lab"
+__email__ = "pylearn-dev@googlegroups"
 
 from pylearn2.testing.skip import skip_if_no_gpu
 skip_if_no_gpu()

--- a/pylearn2/sandbox/cuda_convnet/tests/test_grouped_conv.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/test_grouped_conv.py
@@ -1,0 +1,108 @@
+__authors__ = "Jan Schlueter"
+__credits__ = ["Jan Schlueter"]
+__license__ = "3-clause BSD"
+__maintainer__ = "Ian Goodfellow"
+__email__ = "goodfeli@iro"
+
+from pylearn2.testing.skip import skip_if_no_gpu
+skip_if_no_gpu()
+
+import numpy as np
+from theano import shared
+import itertools
+from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
+from theano.sandbox.cuda.basic_ops import gpu_contiguous, host_from_gpu
+import theano.tensor as T
+from theano.tensor.nnet.conv import conv2d
+from theano import function
+import warnings
+
+def check_results(a, b, tol):
+    if np.abs(a - b).max() > tol:
+        assert type(a) == type(b)
+        assert a.dtype == b.dtype
+        if a.shape != b.shape:
+            print 'cuda-convnet shape: ',a.shape
+            print 'theano shape: ',b.shape
+            assert False
+        err = np.abs(a - b)
+        print 'absolute error range: ', (err.min(), err.max())
+        print 'mean absolute error: ', err.mean()
+        print 'cuda-convnet value range: ', (a.min(), a.max())
+        print 'theano value range: ', (b.min(), b.max())
+        assert False
+
+
+def test_match_grouped_conv():
+
+    # Tests that convolution with numGroups > 1 does the right thing.
+
+    for partial_sum in [0, 1, 4]:
+        for groups in [2, 4]:
+            rng = np.random.RandomState([2014,5,19])
+
+            # define inputs
+            batch_size = 128
+            rows = 7
+            cols = 9
+            channels = 16  # must be a multiple of groups*4 for the weight gradient to work
+            filter_rows = 4
+            filter_cols = filter_rows
+            num_filters = 64  # must be a multiple of groups*16 for anything to work
+
+            images = shared(rng.uniform(-1., 1., (channels, rows, cols,
+                batch_size)).astype('float32'), name='images')
+            filters = shared(rng.uniform(-1., 1., (channels / groups, filter_rows,
+                filter_cols, num_filters)).astype('float32'), name='filters')
+
+            # define graph using cuda-convnet
+            gpu_images = gpu_contiguous(images)
+            gpu_filters = gpu_contiguous(filters)
+
+            output = FilterActs(partial_sum=partial_sum, groups=groups)(gpu_images, gpu_filters)
+            image_grad = T.grad(output.sum(), images)
+            filter_grad = T.grad(output.sum(), filters)
+
+            # define graph using theano's conv2d
+            # that's a bit cumbersome because we need to handle groups ourselves
+            # - convert from c01b to bc01 layout and flip filters
+            images_bc01 = images.dimshuffle(3,0,1,2)
+            filters_bc01 = filters.dimshuffle(3,0,1,2)[:,:,::-1,::-1]
+            # - split images by channels
+            channels_per_group = channels / groups
+            split_images = [images_bc01[:, c*channels_per_group:(c+1)*channels_per_group]
+                    for c in xrange(groups)]
+            # - split filters
+            filters_per_group = num_filters / groups
+            split_filters = [filters_bc01[c*filters_per_group:(c+1)*filters_per_group]
+                    for c in xrange(groups)]
+            # - convolve each group
+            split_outputs = [conv2d(input=inp, filters=filt,
+                    image_shape=(batch_size, channels_per_group, rows, cols),
+                    filter_shape=(filters_per_group, channels_per_group, filter_rows, filter_cols))
+                    for inp, filt in itertools.izip(split_images, split_filters)]
+            # - join output channels
+            output_conv2d = T.join(1, *split_outputs)
+            # - convert back from bc01 layout to c01b layout
+            output_conv2d = output_conv2d.dimshuffle(1,2,3,0)
+            # - define gradients (in c01b layout right away)
+            image_grad_conv2d = T.grad(output_conv2d.sum(), images)
+            filter_grad_conv2d = T.grad(output_conv2d.sum(), filters)
+
+            # compile and call function
+            f = function([], [host_from_gpu(output), output_conv2d, host_from_gpu(image_grad), host_from_gpu(image_grad_conv2d), host_from_gpu(filter_grad), host_from_gpu(filter_grad_conv2d)])
+            output, output_conv2d, image_grad, image_grad_conv2d, filter_grad, filter_grad_conv2d = f()
+
+            # check results
+            check_results(output, output_conv2d, 8e-6)
+            check_results(image_grad, image_grad_conv2d, 2e-5)
+            check_results(filter_grad, filter_grad_conv2d, 3e-4)
+
+            warnings.warn("""test_grouped_conv success criterion is not very strict. Can we verify that this is OK?
+                             One possibility is that theano is numerically unstable and Alex's code is better, or
+                             vice versa, or rounding errors just propagate differently.
+                             Probably theano CPU 64 bit is OK but it's worth checking the others.""")
+
+if __name__ == '__main__':
+    test_match_grouped_conv()
+

--- a/pylearn2/sandbox/cuda_convnet/weight_acts.cu
+++ b/pylearn2/sandbox/cuda_convnet/weight_acts.cu
@@ -668,7 +668,6 @@ void _weightActs(NVMatrix& images, NVMatrix& hidActs, NVMatrix& targets,
     }
     */
 
-
     assert(targets.getNumRows() == (numModules/partialSum) * numFilterColors*filterPixels);
     assert(targets.getNumCols() == numFilters);
 

--- a/pylearn2/sandbox/cuda_convnet/weight_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/weight_acts.py
@@ -141,11 +141,11 @@ class WeightActs(BaseActs):
 
         * inputs: list of shapes of inputs to this node:
           [(input channels, rows, cols, batch_size),
-           (output channels, rows, cols, batch_size),
-           (2,)]
+          (output channels, rows, cols, batch_size),
+          (2,)]
         * outputs: list of shapes of outputs of this node:
           [(filter channels, filter rows, filter cols, output channels),
-           (input channels, filter rows, filter cols, output channels)]
+          (input channels, filter rows, filter cols, output channels)]
         """
         images, hid_grads, _ = inputs
         kerns, partial = outputs

--- a/pylearn2/sandbox/cuda_convnet/weight_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/weight_acts.py
@@ -66,8 +66,11 @@ class WeightActs(BaseActs):
       Input channels must be divisible by 4.
     * hid_grads: (output channels, rows, cols, batch_size)
       Output channels must be a multiple of 16.
-    * filters: (input channels, filter rows, filter cols, output channels)
-      Filter rows must be the same as filter cols.
+    * output_shape: (filter rows, filter cols)
+      Filter rows must be equal to filter cols.
+    * output: (filter channels, filter rows, filter cols, output channels)
+      Filter channels must be input channels / self.groups, or
+      self.pattern.shape[1]. Filter rows must be equal to filter cols.
 
     Notes
     -----
@@ -87,6 +90,13 @@ class WeightActs(BaseActs):
         .. todo::
 
             WRITEME
+
+        Parameters
+        ----------
+        images : WRITEME
+        hid_grads : WRITEME
+        output_shape : 2-element TensorVariable, optional (?)
+            The spatial shape of a single filter
         """
         if not isinstance(images.type, CudaNdarrayType):
             raise TypeError("WeightActs: expected images.type "
@@ -94,7 +104,7 @@ class WeightActs(BaseActs):
                             "got " + str(images.type))
 
         if not isinstance(hid_grads.type, CudaNdarrayType):
-            raise TypeError("WeightActs: expected hid_acts.type "
+            raise TypeError("WeightActs: expected hid_grads.type "
                             "to be CudaNdarrayType, "
                             "got " + str(hid_grads.type))
 
@@ -162,12 +172,12 @@ class WeightActs(BaseActs):
         fail = sub['fail']
         pad = self.pad
 
-        # convFilterActs will multiply targets by scaleTargets
+        # convWeightActs will multiply targets by scaleTargets
         # then add scaleOutput * (the convolution value)
         # We could make use of this to implement an inplace
         # addconv op but for this op we just want to compute
         # the convolution so we set them to 0 and 1 respectively
-        # Note: there is another version of convFilterActs that
+        # Note: there is another version of convWeightActs that
         # does not take these arguments, but it is just a wrapper
         # around the version that does take them, so we save
         # a function call by using the version that we use.
@@ -176,10 +186,10 @@ class WeightActs(BaseActs):
         #define scaleOutput 1
         """
 
-        if self.dense_connectivity:
-            basic_setup += """
-            #define numGroups 1
-            """
+        assert self.groups >= 1, "groups must be greater than zero"
+        basic_setup += """
+        #define numGroups %d
+        """ % self.groups
 
         basic_setup += """
         #define paddingStart (-%(pad)d)
@@ -210,7 +220,7 @@ class WeightActs(BaseActs):
         # The amount of braces that must be closed at the end
         num_braces = 0
 
-        # Convert images int nv_images, an NVMatrix, for compatibility
+        # Convert images into nv_images, an NVMatrix, for compatibility
         # with the cuda-convnet functions
         setup_nv_images = self._argument_contiguity_check("images") + """
         if (%(images)s->nd != 4)
@@ -239,7 +249,7 @@ class WeightActs(BaseActs):
         """
         num_braces += 2
 
-        # Convert hid_grads int nv_hid_grads, an NVMatrix, for compatibility
+        # Convert hid_grads into nv_hid_grads, an NVMatrix, for compatibility
         # with the cuda-convnet functions
         setup_nv_hid_grads = self._argument_contiguity_check("hid_grads") + """
         if (%(hid_grads)s->nd != 4)
@@ -259,7 +269,7 @@ class WeightActs(BaseActs):
 
         setup_nv_weights_grads = """
         int filters_dims[4];
-        // filters:  (input channels, filter rows, filter cols, output channels)
+        // filters:  (filter channels, filter rows, filter cols, output channels)
 
         npy_intp *shape_dims = PyArray_DIMS(%(output_shape)s);
         npy_intp target_rows, target_cols;
@@ -290,9 +300,17 @@ class WeightActs(BaseActs):
                                                            intp_dtype, 0);
         target_rows = *((npy_intp *)PyArray_GETPTR1(casted_shape, 0));
         target_cols = *((npy_intp *)PyArray_GETPTR1(casted_shape, 1));
-        filters_dims[0] = img_channels;
+        const int filter_channels = img_channels / numGroups;  // TODO: support patterns
+        filters_dims[0] = filter_channels;
         filters_dims[1] = target_rows;
         filters_dims[2] = target_cols;
+        if (numGroups > 1 && filters_dims[0] %% 4 != 0)
+        {
+            PyErr_Format(PyExc_ValueError,
+                "for groups > 1, filters must have a multiple of 4 channels, got %%i",
+                filters_dims[0]);
+            %(fail)s;
+        }
         if (filters_dims[1] != filters_dims[2])
         {
             PyErr_Format(PyExc_ValueError,
@@ -344,6 +362,11 @@ class WeightActs(BaseActs):
 
         num_braces += 1
 
+        if self.pattern is not None:
+            # TODO: obtain int* pointer to pattern array (on host!), then call
+            # _weightActsSparse instead of _weightActs
+            raise NotImplementedError("custom connection patterns not supported yet")
+
         # note: imgSizeX is not specified here, it is computed internally
         # (in _filterActsSparse) by the lines:
         # int imgPixels = images.getNumRows() / numImgColors;
@@ -361,7 +384,7 @@ class WeightActs(BaseActs):
             _weightActs(nv_images, nv_hid_grads, nv_weights_grads,
                         imgSizeY, hidGradsSizeY, hidGradsSizeX, filterSize,
                         paddingStart, moduleStride, img_channels, numGroups,
-                        partialSum, 0, 1);
+                        partialSum, scaleTargets, scaleOutput);
         else {
             NVMatrix nv_partialsum(%(partialsum_storage)s, (numModules / partialSum) *
                      filters_dims[0] * filterSize * filterSize, numFilters,
@@ -374,12 +397,7 @@ class WeightActs(BaseActs):
 
             // sum out axis 0 of nv_partialsum
             #define AXIS 0
-            // scale the contents of nv_weights_grads by 0
-            // i.e., clear out its pre-existing content
-            #define SCALE_THIS 0
-            // scale the new sum by 1, i.e., don't do any scaling
-            #define SCALE_SUM 1
-            nv_weights_grads.addSum(nv_partialsum, AXIS, SCALE_THIS, SCALE_SUM);
+            nv_weights_grads.addSum(nv_partialsum, AXIS, scaleTargets, scaleOutput);
         }
         """
 
@@ -402,4 +420,4 @@ class WeightActs(BaseActs):
 
             WRITEME
         """
-        return (7,)
+        return (8,)


### PR DESCRIPTION
This PR adds support for the `numGroups` argument to the convolution routines of Alex Krizhevsky's cuda-convnet. This is a particular kind of restricted connectivity that splits up the input channels and filters into same-sized groups, than applies each group of filters to its associated group of input channels only. This is termed ["block sparse convolution" in the cuda-convnet documentation](http://code.google.com/p/cuda-convnet/wiki/LayerParams#Block_sparse_convolution_layer).

The PR also prepares the interface for supporting ["random sparse convolution"](http://code.google.com/p/cuda-convnet/wiki/LayerParams#Random_sparse_convolution_layer) via the `dColorIndices` argument to Alex's convolution routines, but does not attempt to implement it.

Finally, the PR includes a test that compares the grouped convolution results of cuda-convnet with results using theano's builtin `conv2d` op (both for the outputs and gradients). Results are close enough to infer that the two implementations attempt to compute the same thing, just with different rounding errors.

One minor thing I'm unsure about: Is the `self.dense_connectivity` field of `BaseActs` used anywhere? I've left it in for now, but it doesn't play any role in the implementation. Let me know if you'd like me to remove it or have any other concerns.

Cheers, Jan