### PR TITLE
Fixed bug in CompositeLayer class and added unit test for it

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -4468,7 +4468,7 @@ class CompositeLayer(Layer):
             An expression for the squared L2 weight decay penalty term for
             this layer.
         """
-        return self._weight_decay_gather('get_weight_decay', coeff)
+        return self._weight_decay_aggregate('get_weight_decay', coeff)
 
     def get_l1_weight_decay(self, coeff):
         """
@@ -4491,7 +4491,7 @@ class CompositeLayer(Layer):
             An expression for the L1 weight decay penalty term for this
             layer.
         """
-        return self._weight_decay_gather('get_l1_weight_decay', coeff)
+        return self._weight_decay_aggregate('get_l1_weight_decay', coeff)
 
     @wraps(Layer.cost)
     def cost(self, Y, Y_hat):

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -1,10 +1,14 @@
+from itertools import product
+
 import numpy as np
 import theano
 from theano import tensor
+
 from pylearn2.models.mlp import (MLP, Linear, Softmax, Sigmoid,
                                  exhaustive_dropout_average,
                                  sampled_dropout_average, CompositeLayer)
 from pylearn2.space import VectorSpace, CompositeSpace
+from pylearn2.utils import is_iterable
 
 
 class IdentityLayer(Linear):
@@ -182,7 +186,7 @@ def test_composite_layer():
         composite_layer.layers[i].set_biases(
             np.zeros(2, dtype=theano.config.floatX)
         )
-    X = theano.tensor.matrix()
+    X = tensor.matrix()
     y = mlp.fprop(X)
     funs = [theano.function([X], y_elem) for y_elem in y]
     x_numeric = np.random.rand(2, 2).astype('float32')
@@ -209,7 +213,7 @@ def test_composite_layer():
             composite_layer.layers[i].set_biases(
                 np.zeros(2, dtype=theano.config.floatX)
             )
-        X = [theano.tensor.matrix() for _ in range(3)]
+        X = [tensor.matrix() for _ in range(3)]
         y = mlp.fprop(X)
         funs = [theano.function(X, y_elem, on_unused_input='ignore')
                 for y_elem in y]
@@ -219,3 +223,25 @@ def test_composite_layer():
         assert all([all([np.all(x_numeric[i] == y_numeric[j])
                          for j in inputs_to_layers[i]])
                     for i in inputs_to_layers])
+
+    # Get the weight decay expressions from a composite layer
+    composite_layer = CompositeLayer('composite_layer',
+                                     [Linear(2, 'h0', irange=0.1),
+                                      Linear(2, 'h1', irange=0.1)])
+    input_space = VectorSpace(dim=10)
+    mlp = MLP(input_space=input_space, layers=[composite_layer])
+    for attr, coeff in product(['get_weight_decay', 'get_l1_weight_decay'],
+                               [[0.7, 0.3], 0.5]):
+        f = theano.function([], getattr(composite_layer, attr)(coeff))
+        if is_iterable(coeff):
+            g = theano.function(
+                [], tensor.sum([getattr(layer, attr)(c) for c, layer
+                                in zip(coeff, composite_layer.layers)])
+            )
+            assert np.allclose(f(), g())
+        else:
+            g = theano.function(
+                [], tensor.sum([getattr(layer, attr)(coeff) for layer
+                                in composite_layer.layers])
+            )
+            assert np.allclose(f(), g())


### PR DESCRIPTION
@axeldavy spotted a mistake in my recently merged CompositeLayer PR; I forgot to rename a method in two places. This should fix that and also add a unit test so that it doesn't happen again.

@dwf
