### PR TITLE
Add error check in DBM

### DIFF
--- a/pylearn2/models/dbm/dbm.py
+++ b/pylearn2/models/dbm/dbm.py
@@ -56,6 +56,12 @@ class DBM(Model):
         self.__dict__.update(locals())
         del self.self
         assert len(hidden_layers) >= 1
+
+        if len(hidden_layers) > 1 and niter <= 1:
+            raise ValueError("with more than one hidden layer, niter needs to "
+                             "be greater than 1; otherwise mean field won't "
+                             "work properly.")
+
         self.setup_rng()
         self.layer_names = set()
         self.visible_layer.set_dbm(self)


### PR DESCRIPTION
This pull request adds an error message clarifying why DBM crashes with `niter=1` and `len(hidden_layers) > 1`.
