### PR TITLE
Add wrapping function to improve MemoryError message

### DIFF
--- a/pylearn2/utils/mem.py
+++ b/pylearn2/utils/mem.py
@@ -22,6 +22,25 @@ def get_memory_usage():
     return int(stdout_list[0])
 
 
+def improve_memory_error_message(error, msg=""):
+    """
+    Raises a TypicalMemoryError if the MemoryError has no messages
+
+    Parameters
+    ---------
+    error: MemoryError
+        An instance of MemoryError
+    msg: string
+        A message explaining what possibly happened
+    """
+    assert isinstance(error, MemoryError)
+
+    if str(error):
+        raise error
+    else:
+        raise TypicalMemoryError(msg)
+
+
 class TypicalMemoryError(MemoryError):
     """
     Memory error that could have been caused by typical errors such

--- a/pylearn2/utils/tests/test_mem.py
+++ b/pylearn2/utils/tests/test_mem.py
@@ -15,3 +15,16 @@ def test_typical_memory_error():
         raise TypicalMemoryError("test")
     except TypicalMemoryError as e:
         pass
+
+
+def test_improve_memory_error_message():
+    try:
+        improve_memory_error_message(MemoryError(), "test") 
+    except MemoryError as e:
+        # message have been "beautified"
+        assert len(str(e))
+
+    try:
+        beautify_memory_error_message(MemoryError("test"), "should not") 
+    except MemoryError as e:
+        assert str(e)=="test"


### PR DESCRIPTION
Fix issue #934

MemoryError message is often empty but not always. Catching MemoryError and raising TypicalMemoryError hides some specific MemoryError message. 

This PR adds a wrapping function `improve_memory_error_message` that raises a TypicalMemoryError only if the MemoryError message is empty.
