### PR TITLE
Fix crash when `git` command is not available

### DIFF
--- a/pylearn2/utils/track_version.py
+++ b/pylearn2/utils/track_version.py
@@ -156,7 +156,7 @@ class LibVersion(object):
             if len(modified):
                 version += ' M'
             return version
-        except:
+        except Exception:
             pass
         finally:
             os.chdir(cwd_backup)


### PR DESCRIPTION
A missing `except:` clause caused pylearn2 to crash the moment a class is constructed when git is not installed.
