### PR TITLE
Maxout L1 weight decay: T.abs doesn't exist.

### DIFF
--- a/pylearn2/models/maxout.py
+++ b/pylearn2/models/maxout.py
@@ -338,7 +338,7 @@ class Maxout(Layer):
             coeff = float(coeff)
         assert isinstance(coeff, float) or hasattr(coeff, 'dtype')
         W, = self.transformer.get_params()
-        return coeff * T.abs(W).sum()
+        return coeff * T.abs_(W).sum()
 
     @functools.wraps(Model.get_weights)
     def get_weights(self):


### PR DESCRIPTION
The correct name it T.abs_
