### PR TITLE
MaxoutConv: get_layer_monitoring_channels mixed state_below and state

### DIFF
--- a/pylearn2/models/maxout.py
+++ b/pylearn2/models/maxout.py
@@ -1051,7 +1051,7 @@ class MaxoutConvC01B(Layer):
 
         if (state is not None) or (state_below is not None):
             if state is None:
-                state = self.fprop(state)
+                state = self.fprop(state_below)
 
             P = state
 


### PR DESCRIPTION
There has been a typo at this location of the file: it should be state_below, not state.
