### PR TITLE
fixed is_numeric_batch() to recognize CudaNdarrays

### DIFF
--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -110,7 +110,11 @@ def is_numeric_batch(batch):
     (e.g. () for empty CompositeSpaces, None for NullSpaces).
     """
     def is_numeric(batch):
-        return isinstance(batch, np.ndarray) or scipy.sparse.issparse(batch)
+        # Uses the 'CudaNdarray' string to avoid importing
+        # theano.sandbox.cuda when it is not available
+        return (isinstance(batch, np.ndarray) or
+                scipy.sparse.issparse(batch) or
+                str(type(batch)) == "<type 'CudaNdarray'>")
 
     return _is_batch_all(batch, is_numeric)
 


### PR DESCRIPTION
is_numeric_batch() didn't recognize CudaNdarrays as being numeric batches. This was causing some implementations of np_validate() to crash inappropriately. Fixed.
