### PR TITLE
Update _window_flip.pyx

### DIFF
--- a/pylearn2/utils/_window_flip.pyx
+++ b/pylearn2/utils/_window_flip.pyx
@@ -12,7 +12,7 @@ from pylearn2.utils.rng import make_np_rng
 
 IF UNAME_SYSNAME == "Windows":
     cdef extern from "stdlib.h":
-        int rand()
+        int rand() nogil
     cdef int rand_r(unsigned int *seedp) nogil:
         return rand()
     log = logging.getLogger(__name__)


### PR DESCRIPTION
Fix: Calling gil-requiring function not allowed without gil
