### PR TITLE
removed special-casing of batch_size == 1 in various places, though not all

### DIFF
--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -1643,6 +1643,9 @@ class Conv2DSpace(SimplyTypedSpace):
         dtype = self._clean_dtype_arg(dtype)
         broadcastable = [False] * 4
         broadcastable[self.axes.index('c')] = (self.num_channels == 1)
+
+        # TODO: special-casing batch_size == 1 has been removed elsewhere. Can
+        # we remove it here too?
         broadcastable[self.axes.index('b')] = (batch_size == 1)
         broadcastable = tuple(broadcastable)
 


### PR DESCRIPTION
A quick fix, since this has caused problems before. I didn't add the special-casing, so not sure yet if this will break tests.

Left one special-case intact, since I wasn't sure what it did. See comment on line 1647.
