### PR TITLE
Eliminate advance indexing

### DIFF
--- a/pylearn2/sandbox/nlp/linear/matrixmul.py
+++ b/pylearn2/sandbox/nlp/linear/matrixmul.py
@@ -29,7 +29,7 @@ class MatrixMul(matrixmul.MatrixMul):
 
         if x.ndim == 2:
             shape = (x.shape[0], x.shape[1] * self._W.shape[1])
-            return self._W[x.flatten()].reshape(shape)
+            return self._W[x.flatten().dimshuffle(0)].reshape(shape)
         elif x.ndim == 1:
             return self._W[x].flatten()
         else:


### PR DESCRIPTION
By converting the matrix to vector, this will eliminate advanced indexing which is very expensive on gpu.
