### PR TITLE
Added basic logger configuration for ./train.py

### DIFF
--- a/pylearn2/train.py
+++ b/pylearn2/train.py
@@ -298,5 +298,6 @@ class SerializationGuard(object):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.ERROR)
     log.error("You probably meant to run scripts/train.py")
     sys.exit(1)


### PR DESCRIPTION
Adding logger configuration for ./train.py. Without this, the warning message will not show up and, hence, can be trouble to newbies.
