### PR TITLE
Fix error in quick-start example

### DIFF
--- a/pylearn2/gui/get_weights_report.py
+++ b/pylearn2/gui/get_weights_report.py
@@ -104,7 +104,8 @@ def get_weights_report(model_path=None,
         if dataset is None:
             logger.info('loading dataset...')
             control.push_load_data(False)
-            dataset = yaml_parse.load(model.dataset_yaml_src)
+            dataset_filename = yaml_parse.load(model.dataset_yaml_src)
+            dataset = serial.load(dataset_filename)
             control.pop_load_data()
             logger.info('...done')
 


### PR DESCRIPTION
Following [Pylearn2's quick-start example](http://deeplearning.net/software/pylearn2/tutorial/index.html#tutorial) leads to the following error when attempting to visualize RBM weights with the show_weights.py script.  

```
Traceback (most recent call last):
  File "../../show_weights.py", line 52, in <module>
    show_weights(args.path, args.rescale, args.border, args.out)
  File "../../show_weights.py", line 28, in show_weights
    border=border)
  File "/home/mmay/Downloads/Installs/pylearn2/pylearn2/gui/get_weights_report.py", line 142, in get_weights_report
    weights_view = dataset.get_weights_view(W)
AttributeError: 'str' object has no attribute 'get_weights_view'
```

A simple fix described [here](http://goo.gl/pczYTx) resolves the issue. 
