### PR TITLE
get_weights_report.py: load dataset from file if it's not built in

### DIFF
--- a/pylearn2/gui/get_weights_report.py
+++ b/pylearn2/gui/get_weights_report.py
@@ -104,7 +104,11 @@ def get_weights_report(model_path=None,
         if dataset is None:
             logger.info('loading dataset...')
             control.push_load_data(False)
+            
             dataset = yaml_parse.load(model.dataset_yaml_src)
+            if model.dataset_yaml_src[:5] != "!obj:":
+                # logger.info('Got a real file!')
+                dataset = serial.load(dataset)
             control.pop_load_data()
             logger.info('...done')
 


### PR DESCRIPTION
As discussed in #1010, there seems to be a bug in `get_weights_report.py` that prevents the completion of the quick start example, and I believe it's due to the difference between built in and imported datasets. This patch checks for builtin datasets using a string comparison, and loads it if necessary. There might be a "proper" method to check this, but I'm just familiarizing myself with the codebase so I used an ad hoc test. It worked for several tests under the tutorials, including the offending CIFAR dataset in the quick start example.
