### PR TITLE
Tabs to spaces in Python files

### DIFF
--- a/pylearn2/datasets/retina.py
+++ b/pylearn2/datasets/retina.py
@@ -271,7 +271,7 @@ def decode(dense_X, img_shp, rings):
 
         WRITEME
 
-	Parameters
+    Parameters
     ----------
     dense_X : WRITEME
         matrix in DenseDesignMatrix format (batch, dim)

--- a/pylearn2/sandbox/cuda_convnet/pthreads.py
+++ b/pylearn2/sandbox/cuda_convnet/pthreads.py
@@ -3,11 +3,11 @@ from theano.configparser import AddConfigVar, StrParam
 AddConfigVar('pthreads.inc_dir',
         "location of pthread.h",
         StrParam(""))
-		
+
 AddConfigVar('pthreads.lib_dir',
         "location of library implementing pthreads",
         StrParam(""))
-		
+
 AddConfigVar('pthreads.lib',
         'name of the library that implements pthreads (e.g. "pthreadVC2" if using pthreadVC2.dll/.lib from pthreads-win32)',
         StrParam(""))

--- a/pylearn2/scripts/mlp/predict_csv.py
+++ b/pylearn2/scripts/mlp/predict_csv.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
 # x is a numpy array
 # x = pickle.load(open(test_path, 'rb'))
-    x = np.loadtxt(test_path, delimiter=',')	# no labels in the file
+    x = np.loadtxt(test_path, delimiter=',') # no labels in the file
 
     y = f(x)
 

--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -588,7 +588,7 @@ class Space(object):
             Necessary because it can be impossible to tell from the
             batch whether it should be treated as a numeric of symbolic
             batch, for example when the batch is the empty tuple (),
-			or NullSpace batch None.
+            or NullSpace batch None.
 
         batch : a theano variable, numpy ndarray, scipy.sparse matrix \
                 or a nested tuple thereof


### PR DESCRIPTION
Rebased version of my earlier pull-request.

I threw out the removal of trailing spaces, since it's not important.  Fixing up leading tabs in Python files can actually prevent some bugs.
