### PR TITLE
warning/raise error if using too old Theano that use cublas v1 interface...

### DIFF
--- a/pylearn2/sandbox/cuda_convnet/__init__.py
+++ b/pylearn2/sandbox/cuda_convnet/__init__.py
@@ -47,7 +47,8 @@ from theano.sandbox import cuda
 from theano import config
 
 
-def check_cuda(feature_name="You are using code that relies on cuda-convnet. Cuda-convnet"):
+def check_cuda(feature_name="You are using code that relies on cuda-convnet. Cuda-convnet",
+               check_enabled=True):
     """
     Call this function before sections of code that depend on the cuda_convnet module.
     It will raise a RuntimeError if the GPU is not available.
@@ -68,5 +69,5 @@ def check_cuda(feature_name="You are using code that relies on cuda-convnet. Cud
         raise RuntimeError("You are using probably a too old Theano version."
                            " That will cause compilation crash. Update Theano")
 
-    if not cuda.cuda_enabled:
+    if check_enabled and not cuda.cuda_enabled:
         raise RuntimeError("%s must run be with theano configured to use the GPU" % feature_name)

--- a/pylearn2/sandbox/cuda_convnet/convnet_compile.py
+++ b/pylearn2/sandbox/cuda_convnet/convnet_compile.py
@@ -14,6 +14,7 @@ from theano.sandbox.cuda import nvcc_compiler
 from shared_code import this_dir
 
 import pylearn2.sandbox.cuda_convnet.pthreads
+from pylearn2.sandbox.cuda_convnet import check_cuda
 
 _logger_name = 'pylearn2.sandbox.cuda_convnet.convnet_compile'
 _logger = logging.getLogger(_logger_name)
@@ -35,6 +36,8 @@ libcuda_convnet_so = os.path.join(cuda_convnet_loc,
 
 
 def convnet_available():
+    check_cuda(check_enabled=False)
+
     # If already compiled, OK
     if convnet_available.compiled:
         _logger.debug('already compiled')


### PR DESCRIPTION
The PR that add the check for the cublas version in Theano is not merged.

This will help have less email about this.
