### PR TITLE
Add documentation for DefaultViewConverter's  `shape` parameter

### DIFF
--- a/pylearn2/datasets/dense_design_matrix.py
+++ b/pylearn2/datasets/dense_design_matrix.py
@@ -1335,7 +1335,7 @@ class DefaultViewConverter(object):
         Number of rows, columns and channels, in the `(rows, cols, channels)`
         format, **no matter in which order the axes are specified**.
     axes : tuple, optional
-        Specifies which axes correspond to what in a batch of data. Must be a
+        Specifies which axis corresponds to what in a batch of data. Must be a
         permutation of `('b', 0, 1, 'c')`, where `'b'` is the batch axis, `'c'`
         is the channel axis, `0` is the row axis and `1` is the column axis.
     """


### PR DESCRIPTION
There was no documentation and I had to take a couple minutes to read the code and figure out why my data, which was not in the `('b', 0, 1, 'c')` format, was messed-up when converting it in topological view: I though that `shape` needed to follow the same order as `axes`.

I added this small bit of documentation so that it's easier to determine which format `shape` expects.
