### PR TITLE
Fix for #1078

### DIFF
--- a/pylearn2/termination_criteria/__init__.py
+++ b/pylearn2/termination_criteria/__init__.py
@@ -97,11 +97,15 @@ class MonitorBased(TerminationCriterion):
         else:
             v = monitor.channels[self._channel_name].val_record
 
+        if not v:
+            # No epochs have been run yet, so continue learning.
+            return True
+
         # The countdown decreases every time the termination criterion is
         # called unless the channel value is lower than the best value times
         # the prop_decrease factor, in which case the countdown is reset to N
         # and the best value is updated
-        if v[- 1] < (1. - self.prop_decrease) * self.best_value:
+        if v[-1] < (1. - self.prop_decrease) * self.best_value:
             self.countdown = self.N
         else:
             self.countdown = self.countdown - 1
@@ -145,6 +149,11 @@ class MatchChannel(TerminationCriterion):
             prev_monitor = getattr(model, self.prev_monitor_name)
             channels = prev_monitor.channels
             prev_channel = channels[self.prev_channel_name]
+
+            if not prev_channel.val_record:
+                # No epochs have been run yet, so continue learning.
+                return True
+
             self.target = prev_channel.val_record[-1]
 
         monitor = model.monitor
@@ -178,6 +187,10 @@ class ChannelTarget(TerminationCriterion):
         channels = monitor.channels
         channel = channels[self.channel_name]
 
+        if not channel.val_record:
+            # No epochs have been run yet, so continue learning.
+            return True
+
         rval = channel.val_record[-1] > self.target
         return rval
 
@@ -200,6 +213,10 @@ class ChannelInf(TerminationCriterion):
         monitor = model.monitor
         channels = monitor.channels
         channel = channels[self.channel_name]
+
+        if not channel.val_record:
+            # No epochs have been run yet, so continue learning.
+            return True
 
         rval = np.isinf(channel.val_record[-1])
         return rval
@@ -237,12 +254,6 @@ class EpochCounter(TerminationCriterion):
     def continue_learning(self, model):
         if not hasattr(self, "_epochs_done"):
             self.initialize(model)
-
-            # if attempting to train a model that has already
-            # reach self._max_epochs, allow one additional
-            # epoch of training
-            if not self._new_epochs:
-                return True
         else:
             self._epochs_done += 1
         return self._epochs_done < self._max_epochs

--- a/pylearn2/termination_criteria/tests/test_init.py
+++ b/pylearn2/termination_criteria/tests/test_init.py
@@ -60,11 +60,11 @@ def test_epoch_counter():
     train_obj = produce_train_obj(new_epochs=False)
     train_obj.main_loop()
     test_epochs(train_obj.model.monitor.get_epochs_seen(), N)
-    # Try training while already reached max_epochs, should stop after 1 epoch
-    # on first continue_learning() call
+
+    # Return without training if the model has already reached max epochs
     train_obj = produce_train_obj(new_epochs=False, model=train_obj.model)
     train_obj.main_loop()
-    test_epochs(train_obj.model.monitor.get_epochs_seen(), N + 1)
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), N)
 
     # Setting max_epochs = 0 should result in no training
     train_obj = produce_train_obj(new_epochs=True, max_epochs=0)

--- a/pylearn2/train.py
+++ b/pylearn2/train.py
@@ -198,18 +198,23 @@ already been reported."""
             while True:
                 if self.exceeded_time_budget(t0, time_budget):
                     break
-                continue_learning = \
-                    self.algorithm.continue_learning(self.model)
-                extension_continue = self.run_callbacks_and_monitoring()
-                assert continue_learning in [True, False, 0, 1]
-                if not continue_learning or not extension_continue:
-                    break
 
                 with log_timing(log, None, level=logging.DEBUG,
                                 callbacks=[self.total_seconds.set_value]):
                     with log_timing(
                             log, None, final_msg='Time this epoch:',
                             callbacks=[self.training_seconds.set_value]):
+
+                        continue_learning = (
+                            self.algorithm.continue_learning(self.model)
+                        )
+                        extension_continue = (
+                            self.run_callbacks_and_monitoring()
+                        )
+                        assert continue_learning in [True, False, 0, 1]
+                        if not continue_learning or not extension_continue:
+                            break
+
                         rval = self.algorithm.train(dataset=self.dataset)
                     if rval is not None:
                         raise ValueError("TrainingAlgorithm.train should not "


### PR DESCRIPTION
Should resolve issue #1078.

While digging around the tests, I also found a bit of odd behavior.  The tests seem to allow one extra epoch of training on a model that has already reached max_epochs.  

>   # Try training while already reached max_epochs, should stop after 1 epoch
>   # on first continue_learning() call

From `pylearn2/termination_criteria/tests/test_init.py`:

```
    # Try training while already reached max_epochs, should stop after 1 epoch
    # on first continue_learning() call
    train_obj = produce_train_obj(new_epochs=False, model=train_obj.model)
    train_obj.main_loop()
    test_epochs(train_obj.model.monitor.get_epochs_seen(), N+1)
```

Is that behavior desirable?
