### PR TITLE
bugfix in new_norb.py, browse_norb.py can now show monocular NORB

### DIFF
--- a/pylearn2/datasets/new_norb.py
+++ b/pylearn2/datasets/new_norb.py
@@ -495,6 +495,11 @@ class NORB(DenseDesignMatrix):
         This state does not include the memmaps' contents. Rather, it includes
         enough info to find the memmap and re-load it from disk in the same
         state.
+
+        Note that pickling a NORB will set its memmaps (self.X and self.y) to
+        be read-only. This is to prevent the memmaps from accidentally being
+        edited after the save. To make them writeable again, the user must
+        explicitly call setflags(write=True) on the memmaps.
         """
         _check_pickling_support()
 
@@ -539,10 +544,21 @@ class NORB(DenseDesignMatrix):
                     'dtype': memmap.dtype,
                     'shape': memmap.shape,
                     'offset': memmap.offset,
-                    'mode': memmap.mode}
+                    # We never want to set mode to w+, even if memmap.mode
+                    # is w+. Otherwise we'll overwrite the memmap's contents
+                    # when we open it.
+                    'mode': 'r+' if memmap.mode in ('r+', 'w+') else 'r'}
 
         result['X_info'] = get_memmap_info(self.X)
         result['y_info'] = get_memmap_info(self.y)
+
+        # This prevents self.X and self.y from being accidentally written to
+        # after the save, thus unexpectedly changing the saved file. If the
+        # user really wants to, they can make the memmaps writeable again
+        # by calling setflags(write=True) on the memmaps.
+        for memmap in (self.X, self.y):
+            memmap.flush()
+            memmap.setflags(write=False)
 
         return result
 


### PR DESCRIPTION
This is a replacement for https://github.com/lisa-lab/pylearn2/pull/1091, with a clean git history.

Fixed a bug in NORB that was only visible when the NORB object was given memmaps instantiated with mode='w+' as its .X or .y fields.

When pickling NORB files, its getstate would replace .X and .y with argument lists for instantiating the memmap files, used to load the memmaps when unpickling. The bug was that these argument lists contained mode='w+' if the memmap was originally created with mode='w+'. When unpickling, this mode was used, causing the memmap to be overwritten. This bug is now fixed (repaced 'w+' with 'r+').

Also, there was a risk that, after pickling a NORB object, a user could still edit its memmaps, causing changes to the "saved" data. To prevent this, when a NORB is pickled, it now automatically switches its memmaps to be read-only. The user must now explicitly switch the memmaps back to read-write if they want to.
