### PR TITLE
Viewer for higher-level convolutional weights

### DIFF
--- a/pylearn2/scripts/browse_conv_weights.py
+++ b/pylearn2/scripts/browse_conv_weights.py
@@ -8,7 +8,10 @@ allows it to display weights from higher levels (which can have 100s
 of input channels), not just the first.
 """
 
-import os, sys, warnings, argparse, pdb
+import os
+import sys
+import warnings
+import argparse
 import numpy
 from pylearn2.models.mlp import MLP, ConvElemwise, CompositeLayer
 from pylearn2.models.maxout import MaxoutConvC01B


### PR DESCRIPTION
A script for interactively browsing higher-level convolutional weights. No fancy image-space visualizations here; just displays the convolutional kernels one at a time.
