### PR TITLE
Fix #1107 Remove mcmc_steps

### DIFF
--- a/pylearn2/costs/dbm.py
+++ b/pylearn2/costs/dbm.py
@@ -315,7 +315,7 @@ class BaseCD(Cost):
                 return x.zeros_like()
             layer_to_pos_samples[layer] = recurse_zeros(mf_state)
 
-        layer_to_pos_samples = model.mcmc_steps(
+        layer_to_pos_samples = model.sampling_procedure.sample(
             layer_to_state=layer_to_pos_samples,
             layer_to_clamp=layer_to_clamp,
             num_steps=self.num_gibbs_steps,

--- a/pylearn2/models/dbm/__init__.py
+++ b/pylearn2/models/dbm/__init__.py
@@ -120,9 +120,12 @@ class DBMSampler(Block):
         layer_to_chains[self.dbm.visible_layer] = inputs
 
         layer_to_clamp = OrderedDict([(self.dbm.visible_layer, True)])
-        layer_to_chains = self.dbm.mcmc_steps(layer_to_chains, self.theano_rng,
-                                              layer_to_clamp=layer_to_clamp,
-                                              num_steps=1)
+        layer_to_chains = self.dbm.sampling_procedure.sample(
+            layer_to_state=layer_to_chains,
+            theano_rng=self.theano_rng,
+            layer_to_clamp=layer_to_clamp,
+            num_steps=1
+        )
 
         rval = layer_to_chains[last_layer]
         rval = last_layer.upward_state(rval)

--- a/pylearn2/models/dbm/dbm.py
+++ b/pylearn2/models/dbm/dbm.py
@@ -513,8 +513,8 @@ class DBM(Model):
 
         It thus implies that the samples are represented as shared variables.
         If you want an expression for a sampling step applied to arbitrary
-        theano variables, use the 'mcmc_steps' method. This is a wrapper around
-        that method.
+        theano variables, use the `DBM.sampling_procedure.sample` method.
+        This is a wrapper around that method.
 
         Parameters
         ----------

--- a/pylearn2/models/dbm/layer.py
+++ b/pylearn2/models/dbm/layer.py
@@ -3026,8 +3026,8 @@ class ConvC01B_MaxPool(HiddenLayer):
         """ Note: this resets parameters!"""
 
         setup_detector_layer_c01b(layer=self,
-                input_space=space, rng=self.dbm.rng,
-                irange=self.irange)
+                                  input_space=space,
+                                  rng=self.dbm.rng,)
 
         if not tuple(space.axes) == ('c', 0, 1, 'b'):
             raise AssertionError("You're not using c01b inputs. Ian is enforcing c01b inputs while developing his pipeline to make sure it runs at maximal speed. If you really don't want to use c01b inputs, you can remove this check and things should work. If they don't work it's only because they're not tested.")


### PR DESCRIPTION
And `setup_detector_layer_c01b` is no longer called with `irange` in pylearn2/models/dbm/layer.py
