### PR TITLE
Ensure a C-contiguous input for ImgActs

### DIFF
--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/gpu_unshared_conv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/gpu_unshared_conv.py
@@ -10,6 +10,7 @@ from theano.sandbox.cuda import CudaNdarrayType
 from theano.gof import local_optimizer
 from theano.sandbox.cuda.opt import register_opt
 from theano.sandbox.cuda import gpu_from_host, host_from_gpu
+from theano.sandbox.cuda.basic_ops import gpu_contiguous
 
 from .unshared_conv import FilterActs
 from .unshared_conv import WeightActs
@@ -546,7 +547,7 @@ def insert_gpu_weight_acts(node):
                     partial_sum=1)
             return [host_from_gpu(gpu_weight_acts(
                 gpu_from_host(images),
-                gpu_from_host(hidacts),
+                gpu_contiguous(hidacts),
                 frows,
                 fcols,
                 ))]
@@ -784,7 +785,7 @@ def insert_gpu_img_acts(node):
                     partial_sum=1)
             return [host_from_gpu(gpu_img_acts(
                 gpu_from_host(filters),
-                gpu_from_host(hidacts),
+                gpu_contiguous(hidacts),
                 irows,
                 icols,
                 ))]

--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/unshared_conv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/unshared_conv.py
@@ -4,7 +4,6 @@ XXX
 
 import numpy
 import theano
-from theano.sandbox.cuda.basic_ops import gpu_contiguous
 
 # Use grad_not_implemented for versions of theano that support it
 try:
@@ -123,7 +122,7 @@ class FilterActs(Base):
                             raise
                     hidacts[gg, :, mR, mC, :] = rc_hidacts
         ostor[0][0] = hidacts
-        
+
         print_sizes = 0
         if print_sizes:
             print 'FilterActs shapes: images', images.shape
@@ -140,7 +139,6 @@ class FilterActs(Base):
         # filters and hidacts must have same dtype, upcast if needed
         if filters.dtype == 'float32' and hidacts.dtype == 'float64':
             filters = theano.tensor.cast(filters, 'float64')
-        hidacts = gpu_contiguous(hidacts)
         gimages = ImgActs(module_stride=self.module_stride)(
                 filters, hidacts, irows, icols)
         # images and hidacts must have same dtype, upcast if needed


### PR DESCRIPTION
Both ImgActs and WeightActs require hidacts to be C-contiguous, but it is not guaranteed in code. This could lead to runtime exception.
resolve #1220 
