### PR TITLE
Fix compilation crash on windows.

### DIFF
--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/raw_img_acts.cu
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/raw_img_acts.cu
@@ -26,6 +26,12 @@
 
 //#include <cudaconv2.cuh>
 
+// For Windows compatibility
+// It is also defined in nvmatrix_kernels.cuh, that is included
+// indirectly by cudaconv2.cuh, but it seem that it was commented.
+// As I don't know why, I just add this typedef here.
+typedef unsigned int uint;
+
 #define LO16(x)     ((x) & 0x0000FFFF)
 #define HI16(x)     ((x) >> 16)
 #define DIVUP(x, y) (((x) + (y) - 1) / (y))


### PR DESCRIPTION
Follow up from: [pylearn-dev] Problems of compile theano function while using GpuImgActs from Pylearn2

The problem was reported by Hailin SHI
