### PR TITLE
using six packaged with Theano

### DIFF
--- a/pylearn2/compat.py
+++ b/pylearn2/compat.py
@@ -1,7 +1,7 @@
 """
 Compatibility layer
 """
-import six
+from theano.compat import six
 
 
 __all__ = ('OrderedDict', )

--- a/pylearn2/config/tests/test_yaml_parse.py
+++ b/pylearn2/config/tests/test_yaml_parse.py
@@ -6,8 +6,8 @@ from __future__ import print_function
 
 import os
 import numpy as np
-import six
-from six.moves import cPickle
+from theano.compat import six
+from theano.compat.six.moves import cPickle
 import tempfile
 from numpy.testing import assert_
 from os import environ, close

--- a/pylearn2/config/yaml_parse.py
+++ b/pylearn2/config/yaml_parse.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 import logging
 import warnings
 
-import six
+from theano.compat import six
 
 is_initialized = False
 additional_environ = None

--- a/pylearn2/costs/cost.py
+++ b/pylearn2/costs/cost.py
@@ -9,7 +9,7 @@ import functools
 import logging
 import warnings
 
-from six.moves import reduce
+from theano.compat.six.moves import reduce
 import theano.tensor as T
 from theano.compat.six.moves import zip as izip
 

--- a/pylearn2/costs/dbm.py
+++ b/pylearn2/costs/dbm.py
@@ -13,7 +13,7 @@ import numpy as np
 import logging
 import warnings
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 RandomStreams = MRG_RandomStreams

--- a/pylearn2/cross_validation/blocks.py
+++ b/pylearn2/cross_validation/blocks.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
 __maintainer__ = "Steven Kearnes"
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.blocks import StackedBlocks
 
 

--- a/pylearn2/datasets/binarized_mnist.py
+++ b/pylearn2/datasets/binarized_mnist.py
@@ -16,7 +16,7 @@ __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.dense_design_matrix import (
     DenseDesignMatrix,
     DefaultViewConverter

--- a/pylearn2/datasets/cifar10.py
+++ b/pylearn2/datasets/cifar10.py
@@ -4,7 +4,7 @@
     WRITEME
 """
 import os
-from six.moves import cPickle, xrange
+from theano.compat.six.moves import cPickle, xrange
 import logging
 _logger = logging.getLogger(__name__)
 

--- a/pylearn2/datasets/cifar100.py
+++ b/pylearn2/datasets/cifar100.py
@@ -3,7 +3,7 @@ The CIFAR-100 dataset.
 """
 import numpy as np
 N = np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.dense_design_matrix import (DenseDesignMatrix,
                                                    DefaultViewConverter)
 from pylearn2.utils import serial

--- a/pylearn2/datasets/dense_design_matrix.py
+++ b/pylearn2/datasets/dense_design_matrix.py
@@ -20,7 +20,7 @@ import logging
 import warnings
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 from pylearn2.datasets import cache
 from pylearn2.utils.iteration import (

--- a/pylearn2/datasets/hdf5.py
+++ b/pylearn2/datasets/hdf5.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     h5py = None
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import warnings
 
 from pylearn2.datasets.dense_design_matrix import (DenseDesignMatrix,

--- a/pylearn2/datasets/hepatitis.py
+++ b/pylearn2/datasets/hepatitis.py
@@ -9,7 +9,7 @@ __author__ = "Ian Goodfellow"
 # http://archive.ics.uci.edu/ml/datasets/Hepatitis
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 from pylearn2.datasets.dense_design_matrix import DenseDesignMatrix
 

--- a/pylearn2/datasets/mnist.py
+++ b/pylearn2/datasets/mnist.py
@@ -10,7 +10,7 @@ __email__ = "pylearn-dev@googlegroups"
 
 import numpy as N
 np = N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets import dense_design_matrix
 from pylearn2.datasets import control
 from pylearn2.datasets import cache

--- a/pylearn2/datasets/preprocessing.py
+++ b/pylearn2/datasets/preprocessing.py
@@ -18,7 +18,7 @@ import time
 import warnings
 import os
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import scipy
 try:
     from scipy import linalg

--- a/pylearn2/datasets/retina.py
+++ b/pylearn2/datasets/retina.py
@@ -4,7 +4,7 @@ Retina-inspired preprocessing as described in
     In *AISTATS* 2009.
 """
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.dense_design_matrix import DefaultViewConverter
 from pylearn2.space import Conv2DSpace
 

--- a/pylearn2/datasets/stl10.py
+++ b/pylearn2/datasets/stl10.py
@@ -10,7 +10,7 @@ __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets import dense_design_matrix
 from pylearn2.utils.serial import load
 from pylearn2.utils import contains_nan

--- a/pylearn2/datasets/svhn.py
+++ b/pylearn2/datasets/svhn.py
@@ -12,7 +12,7 @@ except ImportError:
     warnings.warn("Couldn't import tables, so far SVHN is "
                   "only supported with PyTables")
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from pylearn2.datasets import dense_design_matrix
 from pylearn2.utils.serial import load

--- a/pylearn2/datasets/tests/test_norb.py
+++ b/pylearn2/datasets/tests/test_norb.py
@@ -4,7 +4,7 @@ Unit tests for ./norb.py
 
 import unittest
 import numpy
-import six
+from theano.compat import six
 from pylearn2.datasets.norb import SmallNORB
 from pylearn2.datasets.norb_small import FoveatedNORB
 from pylearn2.datasets.new_norb import NORB

--- a/pylearn2/datasets/tl_challenge.py
+++ b/pylearn2/datasets/tl_challenge.py
@@ -6,7 +6,7 @@ __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 import numpy as N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets import cache, dense_design_matrix
 from pylearn2.utils.string_utils import preprocess
 

--- a/pylearn2/datasets/utlc.py
+++ b/pylearn2/datasets/utlc.py
@@ -6,7 +6,7 @@ The user should use the load_ndarray_dataset or load_sparse_dataset function
 See the file ${PYLEARN2_DATA_PATH}/UTLC/README for details on the datasets.
 """
 
-from six.moves import cPickle
+from theano.compat.six.moves import cPickle
 import gzip
 import os
 

--- a/pylearn2/datasets/zca_dataset.py
+++ b/pylearn2/datasets/zca_dataset.py
@@ -17,7 +17,7 @@ from functools import wraps
 import logging
 import warnings
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.dense_design_matrix import DenseDesignMatrix
 from pylearn2.config import yaml_parse
 from pylearn2.datasets import control

--- a/pylearn2/deprecated/classifier.py
+++ b/pylearn2/deprecated/classifier.py
@@ -24,7 +24,7 @@ __docformat__ = 'restructedtext en'
 
 # Third-party imports
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 from theano import tensor
 

--- a/pylearn2/devtools/tests/docscrape.py
+++ b/pylearn2/devtools/tests/docscrape.py
@@ -10,7 +10,7 @@ import re
 import sys
 import types
 
-import six
+from theano.compat import six
 
 
 class Reader(object):

--- a/pylearn2/energy_functions/tests/test_rbm_energy.py
+++ b/pylearn2/energy_functions/tests/test_rbm_energy.py
@@ -2,7 +2,7 @@ import theano
 theano.config.compute_test_value = 'off'
 from pylearn2.energy_functions.rbm_energy import GRBM_Type_1
 import numpy as N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano.tensor as T
 from theano import function
 from pylearn2.utils import as_floatX

--- a/pylearn2/expr/normalize.py
+++ b/pylearn2/expr/normalize.py
@@ -8,7 +8,7 @@ __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano.tensor as T
 
 from pylearn2.sandbox.cuda_convnet.response_norm import CrossMapNorm

--- a/pylearn2/expr/probabilistic_max_pooling.py
+++ b/pylearn2/expr/probabilistic_max_pooling.py
@@ -25,7 +25,7 @@ __email__ = "pylearn-dev@googlegroups"
 import logging
 import theano.tensor as T
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano import function
 import time

--- a/pylearn2/expr/stochastic_pool.py
+++ b/pylearn2/expr/stochastic_pool.py
@@ -13,7 +13,7 @@ __maintainer__ = "Mehdi Mirza"
 __email__ = "mirzamom@iro"
 
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 from theano import tensor
 from theano.gof.op import get_debug_values

--- a/pylearn2/expr/tests/test_normalize.py
+++ b/pylearn2/expr/tests/test_normalize.py
@@ -10,7 +10,7 @@ __email__ = "pylearn-dev@googlegroups"
 import numpy as np
 import warnings
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano import function
 import theano.tensor as T

--- a/pylearn2/expr/tests/test_probabilistic_max_pooling.py
+++ b/pylearn2/expr/tests/test_probabilistic_max_pooling.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import numpy as np
 import warnings
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano import function
 import theano.tensor as T

--- a/pylearn2/expr/tests/test_stochastic_pool.py
+++ b/pylearn2/expr/tests/test_stochastic_pool.py
@@ -1,5 +1,5 @@
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 from theano.compat.python2x import Counter
 from pylearn2.expr.stochastic_pool import stochastic_max_pool_bc01, weighted_max_pool_bc01

--- a/pylearn2/gui/graph_2D.py
+++ b/pylearn2/gui/graph_2D.py
@@ -4,7 +4,7 @@
     WRITEME
 """
 import numpy as N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 
 

--- a/pylearn2/gui/patch_viewer.py
+++ b/pylearn2/gui/patch_viewer.py
@@ -2,7 +2,7 @@
 Functionality for display and saving images of collections of images patches.
 """
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.dense_design_matrix import DefaultViewConverter
 from pylearn2.utils.image import Image, ensure_Image
 from pylearn2.utils.image import show

--- a/pylearn2/gui/tangent_plot.py
+++ b/pylearn2/gui/tangent_plot.py
@@ -8,7 +8,7 @@ try:
     from matplotlib import pyplot
 except Exception:
     pyplot = None
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 
 def tangent_plot(x, y, s):

--- a/pylearn2/linear/conv2d.py
+++ b/pylearn2/linear/conv2d.py
@@ -12,7 +12,7 @@ __email__ = "pylearn-dev@googlegroups"
 
 import functools
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 import theano.tensor as T
 from theano.tensor.nnet.conv import conv2d

--- a/pylearn2/linear/conv2d_c01b.py
+++ b/pylearn2/linear/conv2d_c01b.py
@@ -20,7 +20,7 @@ import logging
 import numpy as np
 import warnings
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano.sandbox import cuda
 import theano.tensor as T
 

--- a/pylearn2/linear/local_c01b.py
+++ b/pylearn2/linear/local_c01b.py
@@ -15,7 +15,7 @@ __email__ = "pylearn-dev@googlegroups"
 
 import logging
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import warnings
 
 from pylearn2.packaged_dependencies.theano_linear.unshared_conv.localdot import LocalDot

--- a/pylearn2/linear/matrixmul.py
+++ b/pylearn2/linear/matrixmul.py
@@ -10,7 +10,7 @@ __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import tensor as T
 
 from pylearn2.linear.linear_transform import LinearTransform

--- a/pylearn2/model_extensions/tests/test_model_extension.py
+++ b/pylearn2/model_extensions/tests/test_model_extension.py
@@ -2,7 +2,7 @@
 Tests for model_extensions.
 """
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.models import Model
 from pylearn2.model_extensions.model_extension import ModelExtension
 

--- a/pylearn2/models/dbm/dbm.py
+++ b/pylearn2/models/dbm/dbm.py
@@ -12,7 +12,7 @@ import logging
 import numpy as np
 import warnings
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import tensor as T, config
 
 from pylearn2.compat import OrderedDict

--- a/pylearn2/models/dbm/inference_procedure.py
+++ b/pylearn2/models/dbm/inference_procedure.py
@@ -10,7 +10,7 @@ __maintainer__ = "LISA Lab"
 import functools
 import logging
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import gof
 import theano.tensor as T
 import theano

--- a/pylearn2/models/dbm/layer.py
+++ b/pylearn2/models/dbm/layer.py
@@ -12,7 +12,7 @@ __maintainer__ = "LISA Lab"
 import functools
 import logging
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import time
 import warnings
 

--- a/pylearn2/models/dbm/sampling_procedure.py
+++ b/pylearn2/models/dbm/sampling_procedure.py
@@ -9,7 +9,7 @@ __credits__ = ["Ian Goodfellow"]
 __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.compat import OrderedDict
 from pylearn2.utils import py_integer_types
 

--- a/pylearn2/models/differentiable_sparse_coding.py
+++ b/pylearn2/models/differentiable_sparse_coding.py
@@ -11,7 +11,7 @@ __email__ = "pylearn-dev@googlegroups"
 
 import logging
 import numpy as N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano.tensor as T
 
 import theano

--- a/pylearn2/models/gsn.py
+++ b/pylearn2/models/gsn.py
@@ -20,7 +20,7 @@ import functools
 import warnings
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 T = theano.tensor
 

--- a/pylearn2/models/independent_multiclass_logistic.py
+++ b/pylearn2/models/independent_multiclass_logistic.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     LogisticRegression = None
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 logger = logging.getLogger(__name__)
 

--- a/pylearn2/models/kmeans.py
+++ b/pylearn2/models/kmeans.py
@@ -2,7 +2,7 @@
 
 import logging
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.blocks import Block
 from pylearn2.models.model import Model
 from pylearn2.space import VectorSpace

--- a/pylearn2/models/local_coordinate_coding.py
+++ b/pylearn2/models/local_coordinate_coding.py
@@ -8,7 +8,7 @@ from theano import function, shared
 from pylearn2.optimization import linear_cg as cg
 from pylearn2.optimization.feature_sign import feature_sign_search
 import numpy as N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano.tensor as T
 from pylearn2.utils.rng import make_np_rng
 

--- a/pylearn2/models/maxout.py
+++ b/pylearn2/models/maxout.py
@@ -30,7 +30,7 @@ import logging
 import numpy as np
 import warnings
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano.compat.six.moves import zip as izip
 from theano.sandbox import cuda
 from theano import tensor as T

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -13,7 +13,7 @@ import sys
 import warnings
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano.gof.op import get_debug_values
 from theano.sandbox.rng_mrg import MRG_RandomStreams

--- a/pylearn2/models/model.py
+++ b/pylearn2/models/model.py
@@ -7,11 +7,11 @@ __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
 from collections import defaultdict
-from six.moves import zip as izip_no_length_check
+from theano.compat.six.moves import zip as izip_no_length_check
 import numpy as np
 import warnings
 
-import six
+from theano.compat import six
 from theano import tensor as T
 
 from pylearn2.compat import OrderedDict

--- a/pylearn2/models/pca.py
+++ b/pylearn2/models/pca.py
@@ -10,7 +10,7 @@ import sys
 # Third-party imports
 import numpy
 N = numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import warnings
 from scipy import linalg, sparse
 # Warning: ridiculous.

--- a/pylearn2/models/rbm.py
+++ b/pylearn2/models/rbm.py
@@ -9,8 +9,8 @@ import logging
 import numpy
 N = numpy
 np = numpy
-import six
-from six.moves import xrange
+from theano.compat import six
+from theano.compat.six.moves import xrange
 import theano
 from theano import tensor
 from theano.compat.six.moves import zip as izip

--- a/pylearn2/models/s3c.py
+++ b/pylearn2/models/s3c.py
@@ -13,7 +13,7 @@ import time
 import warnings
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config, function
 from theano import scan
 from theano.gof.op import get_debug_values, debug_error_message, debug_assert

--- a/pylearn2/models/tests/test_dbm.py
+++ b/pylearn2/models/tests/test_dbm.py
@@ -13,7 +13,7 @@ import numpy as np
 import random
 assert hasattr(np, 'exp')
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano import function
 from theano.sandbox.rng_mrg import MRG_RandomStreams

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 from itertools import product
 
 import numpy as np
-import six
-from six.moves import xrange
+from theano.compat import six
+from theano.compat.six.moves import xrange
 import theano
 from theano import tensor, config
 from nose.tools import assert_raises

--- a/pylearn2/models/tests/test_mnd.py
+++ b/pylearn2/models/tests/test_mnd.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.models.mnd import DiagonalMND
 from pylearn2.models.mnd import kl_divergence
 from pylearn2.optimization.batch_gradient_descent import BatchGradientDescent

--- a/pylearn2/models/tests/test_reflection_clip.py
+++ b/pylearn2/models/tests/test_reflection_clip.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pylearn2.models.s3c import reflection_clip
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import function
 from theano import shared
 from pylearn2.utils.rng import make_np_rng

--- a/pylearn2/models/tests/test_s3c_inference.py
+++ b/pylearn2/models/tests/test_s3c_inference.py
@@ -7,7 +7,7 @@ from pylearn2.models.s3c import E_Step
 from pylearn2.utils import contains_nan
 from theano import function
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano.tensor as T
 from theano import config
 #from pylearn2.utils import serial

--- a/pylearn2/models/tests/test_svm.py
+++ b/pylearn2/models/tests/test_svm.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from pylearn2.datasets.mnist import MNIST
 from pylearn2.testing.skip import skip_if_no_sklearn, skip_if_no_data
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import unittest
 DenseMulticlassSVM = None
 

--- a/pylearn2/monitor.py
+++ b/pylearn2/monitor.py
@@ -14,7 +14,7 @@ import time
 import warnings
 import logging
 import numpy as np
-import six
+from theano.compat import six
 
 from pylearn2.compat import OrderedDict
 import theano.sparse

--- a/pylearn2/optimization/batch_gradient_descent.py
+++ b/pylearn2/optimization/batch_gradient_descent.py
@@ -14,7 +14,7 @@ import logging
 import time
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 from theano import config
 from theano.printing import var_descriptor

--- a/pylearn2/optimization/feature_sign.py
+++ b/pylearn2/optimization/feature_sign.py
@@ -15,7 +15,7 @@ from itertools import count
 
 import logging
 import numpy as np
-import six
+from theano.compat import six
 from theano.compat.six.moves import zip as izip
 
 log = logging.getLogger(__name__)

--- a/pylearn2/optimization/test_batch_gradient_descent.py
+++ b/pylearn2/optimization/test_batch_gradient_descent.py
@@ -4,7 +4,7 @@ from pylearn2.optimization.batch_gradient_descent import BatchGradientDescent
 import theano.tensor as T
 from pylearn2.utils import sharedX
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano.printing import min_informative_str
 

--- a/pylearn2/optimization/test_linesearch.py
+++ b/pylearn2/optimization/test_linesearch.py
@@ -6,7 +6,7 @@ import warnings
 import theano
 import theano.tensor as TT
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from .linesearch import scalar_armijo_search
 from .linesearch import scalar_search_wolfe2
 

--- a/pylearn2/optimization/test_minres.py
+++ b/pylearn2/optimization/test_minres.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 import theano.tensor as TT
 

--- a/pylearn2/packaged_dependencies/theano_linear/imaging.py
+++ b/pylearn2/packaged_dependencies/theano_linear/imaging.py
@@ -6,7 +6,7 @@
 import logging
 import sys
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.utils.image import Image, ensure_Image
 
 

--- a/pylearn2/packaged_dependencies/theano_linear/spconv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/spconv.py
@@ -10,7 +10,7 @@ To read about different sparse formats, see U{http://www-users.cs.umn.edu/~saad/
 import logging
 import numpy
 from scipy import sparse as scipy_sparse
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 import theano
 import theano.sparse

--- a/pylearn2/packaged_dependencies/theano_linear/test_spconv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/test_spconv.py
@@ -1,4 +1,4 @@
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 activate_test_spconv = 0
 if activate_test_spconv:
     import sys

--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/localdot.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/localdot.py
@@ -5,7 +5,7 @@ WRITEME
 import logging
 from ..linear import LinearTransform
 from .unshared_conv import FilterActs, ImgActs
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano.sandbox import cuda
 if cuda.cuda_available:
     import gpu_unshared_conv # register optimizations

--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/test_localdot.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/test_localdot.py
@@ -4,7 +4,7 @@ import nose
 import unittest
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 
 from .localdot import LocalDot

--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/unshared_conv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/unshared_conv.py
@@ -5,7 +5,7 @@ XXX
 from __future__ import print_function
 
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 
 # Use grad_not_implemented for versions of theano that support it

--- a/pylearn2/rbm_tools.py
+++ b/pylearn2/rbm_tools.py
@@ -1,6 +1,6 @@
 """Tools for estimating the partition function of an RBM"""
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 from theano import tensor, config
 from theano.tensor import nnet

--- a/pylearn2/sandbox/cuda_convnet/bench.py
+++ b/pylearn2/sandbox/cuda_convnet/bench.py
@@ -8,7 +8,7 @@ __email__ = "pylearn-dev@googlegroups"
 from pylearn2.testing.skip import skip_if_no_gpu
 skip_if_no_gpu()
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import shared
 from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
 from theano.tensor.nnet.conv import conv2d

--- a/pylearn2/sandbox/cuda_convnet/specialized_bench.py
+++ b/pylearn2/sandbox/cuda_convnet/specialized_bench.py
@@ -8,7 +8,7 @@ __email__ = "pylearn-dev@googlegroups"
 from pylearn2.testing.skip import skip_if_no_gpu
 skip_if_no_gpu()
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import shared
 from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
 from theano.tensor.nnet.conv import conv2d

--- a/pylearn2/sandbox/cuda_convnet/tests/profile_probabilistic_max_pooling.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/profile_probabilistic_max_pooling.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import theano.tensor as T
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano import function
 import time

--- a/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts_strided.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/test_filter_acts_strided.py
@@ -6,7 +6,7 @@ from pylearn2.testing.skip import skip_if_no_gpu
 skip_if_no_gpu()
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import shared
 from theano.tensor import grad, constant
 from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs

--- a/pylearn2/sandbox/cuda_convnet/tests/test_image_acts_strided.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/test_image_acts_strided.py
@@ -5,7 +5,7 @@ from pylearn2.testing.skip import skip_if_no_gpu
 skip_if_no_gpu()
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import shared
 from theano.tensor import grad, constant
 from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs

--- a/pylearn2/sandbox/cuda_convnet/tests/test_stochastic_pool.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/test_stochastic_pool.py
@@ -1,7 +1,7 @@
 import copy
 
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 from theano.compat.python2x import Counter
 

--- a/pylearn2/sandbox/cuda_convnet/tests/test_weight_acts_strided.py
+++ b/pylearn2/sandbox/cuda_convnet/tests/test_weight_acts_strided.py
@@ -6,7 +6,7 @@ from pylearn2.testing.skip import skip_if_no_gpu
 skip_if_no_gpu()
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import shared
 from theano.tensor import grad, constant
 from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs

--- a/pylearn2/sandbox/lisa_rl/bandit/plot_reward.py
+++ b/pylearn2/sandbox/lisa_rl/bandit/plot_reward.py
@@ -2,7 +2,7 @@ __author__ = "Ian Goodfellow"
 
 from matplotlib import pyplot
 import sys
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 pyplot.hold(True)
 
 from pylearn2.utils import serial

--- a/pylearn2/sandbox/nlp/datasets/text.py
+++ b/pylearn2/sandbox/nlp/datasets/text.py
@@ -1,5 +1,5 @@
 """Datasets for working with text"""
-import six
+from theano.compat import six
 
 
 class TextDatasetMixin(object):

--- a/pylearn2/sandbox/rnn/costs/gradient_clipping.py
+++ b/pylearn2/sandbox/rnn/costs/gradient_clipping.py
@@ -3,7 +3,7 @@ Implements gradient clipping as a cost wrapper.
 """
 from functools import wraps
 
-import six
+from theano.compat import six
 from theano import tensor
 
 from pylearn2.compat import OrderedDict

--- a/pylearn2/sandbox/rnn/models/mlp_hook.py
+++ b/pylearn2/sandbox/rnn/models/mlp_hook.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import logging
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.sandbox.rnn.space import SequenceSpace, SequenceDataSpace
 from pylearn2.space import CompositeSpace
 from pylearn2.utils.track_version import MetaLibVersion

--- a/pylearn2/sandbox/rnn/models/rnn.py
+++ b/pylearn2/sandbox/rnn/models/rnn.py
@@ -4,8 +4,8 @@ Recurrent Neural Network Layer
 from functools import wraps
 
 import numpy as np
-import six
-from six.moves import xrange
+from theano.compat import six
+from theano.compat.six.moves import xrange
 from theano import tensor
 from theano import config, scan
 

--- a/pylearn2/scripts/datasets/make_downsampled_stl10.py
+++ b/pylearn2/scripts/datasets/make_downsampled_stl10.py
@@ -12,7 +12,7 @@ This script also translates the data to lie in [-127.5, 127.5] instead of
 
 from __future__ import print_function
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.stl10 import STL10
 from pylearn2.datasets.preprocessing import Downsample
 from pylearn2.utils import string_utils as string

--- a/pylearn2/scripts/datasets/make_mnistplus.py
+++ b/pylearn2/scripts/datasets/make_mnistplus.py
@@ -17,7 +17,7 @@ Brodatz texture dataset.
 5. Perform embossing operation, given fixed lighting position obtained in 4.
 """
 import numpy
-from six.moves import xrange, cPickle as pickle
+from theano.compat.six.moves import xrange, cPickle as pickle
 import pylab as pl
 
 from copy import copy

--- a/pylearn2/scripts/dbm/dbm_metrics.py
+++ b/pylearn2/scripts/dbm/dbm_metrics.py
@@ -34,7 +34,7 @@ import warnings
 import numpy
 import logging
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 import theano.tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams

--- a/pylearn2/scripts/dbm/show_negative_chains.py
+++ b/pylearn2/scripts/dbm/show_negative_chains.py
@@ -12,7 +12,7 @@ from pylearn2.utils import serial
 from pylearn2.datasets import control
 from pylearn2.config import yaml_parse
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.gui.patch_viewer import PatchViewer
 
 ignore, model_path = sys.argv

--- a/pylearn2/scripts/dbm/show_reconstructions.py
+++ b/pylearn2/scripts/dbm/show_reconstructions.py
@@ -18,7 +18,7 @@ from pylearn2.utils import serial
 import sys
 from pylearn2.config import yaml_parse
 from pylearn2.gui.patch_viewer import PatchViewer
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import function
 
 rows = 5

--- a/pylearn2/scripts/dbm/show_samples.py
+++ b/pylearn2/scripts/dbm/show_samples.py
@@ -20,7 +20,7 @@ import sys
 from pylearn2.config import yaml_parse
 from pylearn2.gui.patch_viewer import PatchViewer
 import time
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import function
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 import numpy as np

--- a/pylearn2/scripts/dbm/top_filters.py
+++ b/pylearn2/scripts/dbm/top_filters.py
@@ -28,7 +28,7 @@ instead of displaying them. This can be useful when working over ssh.
 import sys
 from pylearn2.utils import serial
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.gui.patch_viewer import PatchViewer
 from pylearn2.gui.patch_viewer import make_viewer
 from pylearn2.config import yaml_parse

--- a/pylearn2/scripts/gsn_example.py
+++ b/pylearn2/scripts/gsn_example.py
@@ -9,7 +9,7 @@ import cPickle as pickle
 import itertools
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano.tensor as T
 
 from pylearn2.expr.activations import rescaled_softmax

--- a/pylearn2/scripts/icml_2013_wrepl/black_box/make_submission.py
+++ b/pylearn2/scripts/icml_2013_wrepl/black_box/make_submission.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import sys
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 def usage():
     print("""usage: python make_submission.py model.pkl submission.csv)

--- a/pylearn2/scripts/icml_2013_wrepl/emotions/make_submission.py
+++ b/pylearn2/scripts/icml_2013_wrepl/emotions/make_submission.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import sys
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 def usage():
     print("""usage: python make_submission.py model.pkl submission.csv)

--- a/pylearn2/scripts/icml_2013_wrepl/multimodal/lcn.py
+++ b/pylearn2/scripts/icml_2013_wrepl/multimodal/lcn.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 import sys
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.utils import image
 from pylearn2.utils import serial
 from pylearn2.utils.string_utils import preprocess

--- a/pylearn2/scripts/icml_2013_wrepl/multimodal/make_submission.py
+++ b/pylearn2/scripts/icml_2013_wrepl/multimodal/make_submission.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import numpy as np
 import sys
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import function
 from theano import tensor as T
 

--- a/pylearn2/scripts/jobman/experiment.py
+++ b/pylearn2/scripts/jobman/experiment.py
@@ -1,7 +1,7 @@
 # Local imports
 import pylearn2.config.yaml_parse
 
-import six
+from theano.compat import six
 import jobman
 from jobman.tools import expand, flatten
 

--- a/pylearn2/scripts/papers/jia_huang_wkshp_11/assemble.py
+++ b/pylearn2/scripts/papers/jia_huang_wkshp_11/assemble.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import numpy as np
 import os
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 #check that the right files are present
 names = os.listdir('.')

--- a/pylearn2/scripts/papers/jia_huang_wkshp_11/extract_features.py
+++ b/pylearn2/scripts/papers/jia_huang_wkshp_11/extract_features.py
@@ -19,7 +19,7 @@ import warnings
 import time
 import copy
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from theano import config
 from theano import tensor as T
 from theano import function

--- a/pylearn2/scripts/papers/jia_huang_wkshp_11/fit_final_model.py
+++ b/pylearn2/scripts/papers/jia_huang_wkshp_11/fit_final_model.py
@@ -7,7 +7,7 @@ from galatea.s3c.feature_loading import get_features
 from pylearn2.utils import serial
 from pylearn2.datasets.cifar10 import CIFAR10
 from pylearn2.datasets.cifar100 import CIFAR100
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import gc
 gc.collect()
 

--- a/pylearn2/scripts/plot_monitor.py
+++ b/pylearn2/scripts/plot_monitor.py
@@ -22,7 +22,7 @@ import gc
 import numpy as np
 import sys
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.utils import serial
 from theano.printing import _TagGenerator
 from pylearn2.utils.string_utils import number_aware_alphabetical_key

--- a/pylearn2/scripts/show_binocular_greyscale_examples.py
+++ b/pylearn2/scripts/show_binocular_greyscale_examples.py
@@ -14,7 +14,7 @@ __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
 import numpy as N
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.gui import patch_viewer
 from pylearn2.config import yaml_parse
 from optparse import OptionParser

--- a/pylearn2/scripts/show_examples.py
+++ b/pylearn2/scripts/show_examples.py
@@ -15,7 +15,7 @@ __email__ = "pylearn-dev@googlegroups"
 
 import argparse
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.gui import patch_viewer
 from pylearn2.config import yaml_parse
 

--- a/pylearn2/scripts/tests/test_show_weights.py
+++ b/pylearn2/scripts/tests/test_show_weights.py
@@ -1,7 +1,7 @@
 """
 Tests for the show_weights.py script
 """
-from six.moves import cPickle
+from theano.compat.six.moves import cPickle
 import os
 
 from pylearn2.testing.skip import skip_if_no_matplotlib

--- a/pylearn2/scripts/tests/test_summarize_model.py
+++ b/pylearn2/scripts/tests/test_summarize_model.py
@@ -1,7 +1,7 @@
 """
 A unit test for the summarize_model.py script
 """
-from six.moves import cPickle
+from theano.compat.six.moves import cPickle
 import os
 
 from pylearn2.testing.skip import skip_if_no_matplotlib

--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -35,7 +35,7 @@ __email__ = "pylearn-dev@googlegroups"
 import functools
 import warnings
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 import theano.sparse
 from theano import tensor

--- a/pylearn2/space/tests/test_space.py
+++ b/pylearn2/space/tests/test_space.py
@@ -7,7 +7,7 @@ import itertools
 import warnings
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 from theano import tensor
 

--- a/pylearn2/testing/datasets.py
+++ b/pylearn2/testing/datasets.py
@@ -7,7 +7,7 @@ __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.datasets.dense_design_matrix import DenseDesignMatrix
 
 

--- a/pylearn2/tests/test_monitor.py
+++ b/pylearn2/tests/test_monitor.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import numpy as np
 import warnings
 from nose.tools import assert_raises
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 from theano.compat import exc_message
 from theano import shared

--- a/pylearn2/train_extensions/tests/test_window_flip.py
+++ b/pylearn2/train_extensions/tests/test_window_flip.py
@@ -1,7 +1,7 @@
 import hashlib
 import itertools
 import numpy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.train_extensions.window_flip import WindowAndFlip
 from pylearn2.train_extensions.window_flip import WindowAndFlipC01B
 

--- a/pylearn2/training_algorithms/default.py
+++ b/pylearn2/training_algorithms/default.py
@@ -3,7 +3,7 @@ A generic training algorithm that implements no real training code of its
 own but just calls the model.train_batch method on minibatches of data.
 """
 import functools
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.monitor import Monitor
 from pylearn2.training_algorithms.training_algorithm import TrainingAlgorithm
 from pylearn2.utils import safe_zip

--- a/pylearn2/training_algorithms/learning_rule.py
+++ b/pylearn2/training_algorithms/learning_rule.py
@@ -5,7 +5,7 @@ algorithm.
 import numpy as np
 import warnings
 
-import six
+from theano.compat import six
 from theano import config
 from theano import tensor as T
 

--- a/pylearn2/training_algorithms/sgd.py
+++ b/pylearn2/training_algorithms/sgd.py
@@ -15,7 +15,7 @@ import logging
 import warnings
 
 import numpy as np
-import six
+from theano.compat import six
 from theano import config
 from theano import function
 from theano.gof.op import get_debug_values

--- a/pylearn2/training_algorithms/tests/test_bgd.py
+++ b/pylearn2/training_algorithms/tests/test_bgd.py
@@ -1,4 +1,4 @@
-from six.moves import cStringIO, xrange
+from theano.compat.six.moves import cStringIO, xrange
 import numpy as np
 
 import theano.tensor as T

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import numpy as np
-from six.moves import cStringIO, xrange
+from theano.compat.six.moves import cStringIO, xrange
 import theano.tensor as T
 from theano.tests import disturb_mem
 from theano.tests.record import Record, RecordMode

--- a/pylearn2/utils/__init__.py
+++ b/pylearn2/utils/__init__.py
@@ -16,7 +16,7 @@ control = None
 cuda = None
 
 import numpy as np
-import six
+from theano.compat import six
 
 from functools import partial
 
@@ -390,12 +390,12 @@ def grad(*args, **kwargs):
 
 
 # Groups of Python types that are often used together in `isinstance`
-if six.PY2:
-    py_integer_types = (int, long, np.integer)
-    py_number_types = (int, long, float, complex, np.number)
-else:
+if six.PY3:
     py_integer_types = (int, np.integer)
     py_number_types = (int, float, complex, np.number)
+else:
+    py_integer_types = (int, long, np.integer)
+    py_number_types = (int, long, float, complex, np.number)
 
 py_float_types = (float, np.floating)
 py_complex_types = (complex, np.complex)

--- a/pylearn2/utils/bit_strings.py
+++ b/pylearn2/utils/bit_strings.py
@@ -7,7 +7,7 @@ __email__ = "wardefar@iro"
 __maintainer__ = "David Warde-Farley"
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 
 def all_bit_strings(bits, dtype='uint8'):

--- a/pylearn2/utils/datasets.py
+++ b/pylearn2/utils/datasets.py
@@ -12,7 +12,7 @@ import warnings
 # Third-party imports
 import numpy
 import scipy
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 try:
     from matplotlib import pyplot

--- a/pylearn2/utils/exc.py
+++ b/pylearn2/utils/exc.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 
 from pylearn2.utils.common_strings import environment_variable_essay
-import six
+from theano.compat import six
 
 
 class EnvironmentVariableError(Exception):

--- a/pylearn2/utils/image.py
+++ b/pylearn2/utils/image.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 plt = None
 axes = None
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import warnings
 try:
     import matplotlib.pyplot as plt

--- a/pylearn2/utils/insert_along_axis.py
+++ b/pylearn2/utils/insert_along_axis.py
@@ -11,7 +11,7 @@ __maintainer__ = "David Warde-Farley"
 __email__ = "wardefar@iro"
 
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 import theano.tensor as tensor
 from theano.gradient import grad_not_implemented

--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -18,7 +18,7 @@ Presets:
 from __future__ import division
 
 import numpy as np
-import six
+from theano.compat import six
 
 from pylearn2.space import CompositeSpace
 from pylearn2.utils import safe_izip, wraps

--- a/pylearn2/utils/logger.py
+++ b/pylearn2/utils/logger.py
@@ -27,7 +27,7 @@ __maintainer__ = "David Warde-Farley"
 import logging
 import sys
 from logging import Handler, Formatter
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 
 class CustomFormatter(Formatter):

--- a/pylearn2/utils/mnist_ubyte.py
+++ b/pylearn2/utils/mnist_ubyte.py
@@ -12,7 +12,7 @@ __maintainer__ = "David Warde-Farley"
 
 import struct
 import numpy
-import six
+from theano.compat import six
 
 MNIST_IMAGE_MAGIC = 2051
 MNIST_LABEL_MAGIC = 2049

--- a/pylearn2/utils/pooling.py
+++ b/pylearn2/utils/pooling.py
@@ -2,7 +2,7 @@
 Support code for pooling operations (in pooled ICA type models, for now).
 """
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import theano
 import warnings
 try:

--- a/pylearn2/utils/rng.py
+++ b/pylearn2/utils/rng.py
@@ -12,7 +12,7 @@ __license__ = "3-clause BSD"
 __email__ = "bouthilx@iro"
 
 import numpy
-import six
+from theano.compat import six
 
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 # more distributions but slower

--- a/pylearn2/utils/serial.py
+++ b/pylearn2/utils/serial.py
@@ -12,7 +12,7 @@ except ImportError:
 import pickle
 import logging
 import numpy as np
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import os
 import time
 import warnings

--- a/pylearn2/utils/string_utils.py
+++ b/pylearn2/utils/string_utils.py
@@ -3,7 +3,7 @@
 import os
 import re
 
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 
 from pylearn2.utils.exc import EnvironmentVariableError, NoDataPathError
 from pylearn2.utils.exc import reraise_as

--- a/pylearn2/utils/tests/test_serial.py
+++ b/pylearn2/utils/tests/test_serial.py
@@ -2,7 +2,7 @@
 Tests for the pylearn2.utils.serial module. Currently only tests
 read_bin_lush_matrix and load_train_file methods.
 """
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 import pylearn2
 from pylearn2.utils.serial import read_bin_lush_matrix, load_train_file
 import numpy as np

--- a/pylearn2/utils/tests/test_string_utils.py
+++ b/pylearn2/utils/tests/test_string_utils.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import os
 import uuid
-from six.moves import xrange
+from theano.compat.six.moves import xrange
 from pylearn2.utils.string_utils import find_number
 from pylearn2.utils.string_utils import preprocess
 from pylearn2.utils.string_utils import tokenize_by_number

--- a/pylearn2/utils/tests/test_video.py
+++ b/pylearn2/utils/tests/test_video.py
@@ -1,6 +1,6 @@
 """Tests for pylearn2.utils.video"""
 import numpy
-import six
+from theano.compat import six
 from pylearn2.compat import OrderedDict
 from pylearn2.utils.video import FrameLookup, spatiotemporal_cubes
 

--- a/pylearn2/utils/track_version.py
+++ b/pylearn2/utils/track_version.py
@@ -29,7 +29,7 @@ import socket
 import subprocess
 import sys
 
-import six
+from theano.compat import six
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,7 @@ setup(
     license='BSD 3-clause license',
     long_description=open('README.rst').read(),
     dependency_links=['git+http://github.com/Theano/Theano.git#egg=Theano'],
-    install_requires=['numpy>=1.5', 'pyyaml', 'argparse', "Theano",
-                      "six"],
+    install_requires=['numpy>=1.5', 'pyyaml', 'argparse', "Theano"],
     package_data={
         '': ['*.cu', '*.cuh', '*.h'],
     },


### PR DESCRIPTION
Replace following imports:

```
import six
from six.moves import ...
```

to

```
from theano.compat import six
from theano.compat.six.moves import ...
```

This removes the dependency on six introduced in #1240.
