### PR TITLE
improve compatibility for python 3

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -10,5 +10,6 @@ else
     # present. We can't download the original as it is too big to
     # download each time. If present run: python make_dataset.py
     (cd pylearn2/scripts/tutorials/grbm_smd && wget http://www.iro.umontreal.ca/~lisa/datasets/cifar10_preprocessed_train.pkl)
+    if [ $TRAVIS_PYTHON_VERSION = '3.4' ]; then python pylearn2/devtools/convert_pkl.py pylearn2/scripts/tutorials/grbm_smd/cifar10_preprocessed_train.pkl; fi
     THEANO_FLAGS="$FLAGS",blas.ldflags="-lblas -lgfortran",-warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise theano-nose -v $PART
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda create --yes -q -n py26 python=2.6 cython=0.2 pillow numpy=1.6 numpydoc scipy=0.11 pytables=3.0 numexpr=2.2.2 nose=1.1 pyyaml sphinx argparse pyflakes pip
-  - source activate py26
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda create --yes -q -n pyenv python=2.6 cython=0.2 pillow numpy=1.6 numpydoc scipy=0.11 pytables=3.0 numexpr=2.2.2 nose=1.1 pyyaml sphinx pyflakes argparse pip; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then conda create --yes -q -n pyenv python=3.4 cython=0.21.1 pillow numpy=1.9.1 numpydoc scipy=0.14.0 pytables=3.1.1 numexpr=2.3.1 nose=1.3.4 pyyaml sphinx pyflakes pip; fi
+  - source activate pyenv
   - pip install -q git+git://git.assembla.com/jobman.git
   - pip install -q --no-deps git+git://github.com/Theano/Theano.git
   - pip install -q nose-exclude

--- a/pylearn2/classifier.py
+++ b/pylearn2/classifier.py
@@ -9,12 +9,12 @@ import warnings
 warnings.warn("pylearn2.classifier has been deprecated and will be removed "
         "from the library on or after Aug 24, 2014.")
 
-from deprecated.classifier import Block
-from deprecated.classifier import CumulativeProbabilitiesLayer
-from deprecated.classifier import LogisticRegressionLayer
-from deprecated.classifier import Model
-from deprecated.classifier import VectorSpace
-from deprecated.classifier import numpy
-from deprecated.classifier import sharedX
-from deprecated.classifier import tensor
-from deprecated.classifier import theano
+from .deprecated.classifier import Block
+from .deprecated.classifier import CumulativeProbabilitiesLayer
+from .deprecated.classifier import LogisticRegressionLayer
+from .deprecated.classifier import Model
+from .deprecated.classifier import VectorSpace
+from .deprecated.classifier import numpy
+from .deprecated.classifier import sharedX
+from .deprecated.classifier import tensor
+from .deprecated.classifier import theano

--- a/pylearn2/costs/dbm.py
+++ b/pylearn2/costs/dbm.py
@@ -9,11 +9,13 @@ __credits__ = ["Ian Goodfellow"]
 __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 
+import collections
 import numpy as np
 import logging
+import operator
 import warnings
 
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import reduce, xrange
 from theano import config
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 RandomStreams = MRG_RandomStreams
@@ -369,7 +371,7 @@ class PCD(DefaultDataSpecsMixin, BaseCD):
         layer_to_chains = model.make_layer_to_state(self.num_chains)
 
         def recurse_check(l):
-            if isinstance(l, (list, tuple)):
+            if isinstance(l, (list, tuple, collections.ValuesView)):
                 for elem in l:
                     recurse_check(elem)
             else:
@@ -800,7 +802,7 @@ class MF_L1_ActCost(DefaultDataSpecsMixin, Cost):
         if len(layer_costs) == 0:
             return T.as_tensor_variable(0.)
         else:
-            total_cost = reduce(lambda x, y: x + y, layer_costs)
+            total_cost = reduce(operator.add, layer_costs)
         total_cost.name = 'MF_L1_ActCost'
 
         assert total_cost.ndim == 0
@@ -1023,7 +1025,7 @@ class WeightDecay(NullDataSpecsMixin, Cost):
             rval.name = '0_weight_decay'
             return rval
         else:
-            total_cost = reduce(lambda x, y: x + y, layer_costs)
+            total_cost = reduce(operator.add, layer_costs)
         total_cost.name = 'DBM_WeightDecay'
 
         assert total_cost.ndim == 0

--- a/pylearn2/costs/mlp/__init__.py
+++ b/pylearn2/costs/mlp/__init__.py
@@ -4,7 +4,10 @@ Costs for use with the MLP model class.
 __authors__ = 'Vincent Archambault-Bouffard, Ian Goodfellow'
 __copyright__ = "Copyright 2013, Universite de Montreal"
 
+import operator
+
 from theano import tensor as T
+from theano.compat.six.moves import reduce
 
 from pylearn2.costs.cost import Cost, DefaultDataSpecsMixin, NullDataSpecsMixin
 from pylearn2.utils import safe_izip
@@ -100,7 +103,7 @@ class WeightDecay(NullDataSpecsMixin, Cost):
             rval.name = '0_weight_decay'
             return rval
         else:
-            total_cost = reduce(lambda x, y: x + y, layer_costs)
+            total_cost = reduce(operator.add, layer_costs)
         total_cost.name = 'MLP_WeightDecay'
 
         assert total_cost.ndim == 0
@@ -159,7 +162,7 @@ class L1WeightDecay(NullDataSpecsMixin, Cost):
             rval.name = '0_l1_penalty'
             return rval
         else:
-            total_cost = reduce(lambda x, y: x + y, layer_costs)
+            total_cost = reduce(operator.add, layer_costs)
         total_cost.name = 'MLP_L1Penalty'
 
         assert total_cost.ndim == 0

--- a/pylearn2/dataset_get/dataset-get.py
+++ b/pylearn2/dataset_get/dataset-get.py
@@ -24,6 +24,8 @@ import urllib,urllib2
 import tarfile
 import subprocess
 
+from theano.compat.six.moves import input
+
 logger = logging.getLogger(__name__)
 
 
@@ -817,7 +819,7 @@ def upgrade_packages(packages_to_upgrade, hook=None ):
             readable_size = packages_sources[this_package].readable_size
             logger.info("{0} ({1})".format(this_package, readable_size))
 
-        r=raw_input("Proceed? [yes/N] ")
+        r = input("Proceed? [yes/N] ")
         if r=='y' or r=='yes':
             for  this_package in packages_really_to_upgrade:
                 install_upgrade( packages_sources[this_package], upgrade=True, progress_hook=hook )
@@ -872,7 +874,7 @@ def install_packages( packages_to_install, force_install=False, hook=None ):
             readable_size = packages_sources[this_package].readable_size
             logger.info("{0} ({1})".format(this_package, readable_size))
 
-        r=raw_input("Proceed? [yes/N] ")
+        r = input("Proceed? [yes/N] ")
         if r=='y' or r=='yes':
             for  this_package in packages_really_to_install:
                 install_upgrade( packages_sources[this_package], upgrade=False, progress_hook=hook )
@@ -913,12 +915,12 @@ def install_packages_from_file( packages_to_install ):
             packages.append(corename(this_package))
         logger.info(' '.join(packages))
 
-        r=raw_input("Proceed? [yes/N] ")
+        r = input("Proceed? [yes/N] ")
         if r=='y' or r=='yes':
             for  this_package in packages_really_to_install:
                 #install_upgrade( this_package, upgrade=False, progress_hook=hook )
                 if os.path.exists(dataset_data_path+corename(this_package)):
-                    r=raw_input("[in] '%s' already installed, overwrite? [yes/N] " % corename(this_package))
+                    r = input("[in] '%s' already installed, overwrite? [yes/N] " % corename(this_package))
 
                     if r!='y' and r!='yes':
                         logger.info("[in] skipping package "
@@ -995,7 +997,7 @@ def remove_packages( packages_to_remove ):
             packages.append(this_package)
         logger.info(' '.join(packages))
 
-        r=raw_input("Proceed? [yes/N] ")
+        r = input("Proceed? [yes/N] ")
         if r=='y' or r=='yes':
             for  this_package in packages_really_to_remove:
                 remove_package( installed_packages_list[this_package], dataset_data_path )

--- a/pylearn2/dataset_get/helper-scripts/make-archive.py
+++ b/pylearn2/dataset_get/helper-scripts/make-archive.py
@@ -9,7 +9,9 @@ __licence__   = "BSD 3-Clause http://www.opensource.org/licenses/BSD-3-Clause "
 
 
 import logging
-import os,re,sys,tarfile
+import os, sys, tarfile
+
+from theano.compat.six.moves import input
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +70,7 @@ def checks(path):
 def create_archive( source, archive_name ):
 
     if os.path.exists(archive_name):
-        r= raw_input("'%s' exists, overwrite? [yes/N] " % archive_name)
+        r = input("'%s' exists, overwrite? [yes/N] " % archive_name)
         if (r!="y") and (r!="yes"):
             logger.info("taking '{0}' for no, so there.".format(r))
             #bail out

--- a/pylearn2/datasets/norb_small.py
+++ b/pylearn2/datasets/norb_small.py
@@ -7,6 +7,8 @@ import numpy
 np = numpy
 import os
 
+from theano.compat.six.moves import reduce
+
 from pylearn2.datasets import dense_design_matrix
 from pylearn2.datasets import retina
 from pylearn2.datasets.cache import datasetCache

--- a/pylearn2/datasets/tests/test_transformer_dataset.py
+++ b/pylearn2/datasets/tests/test_transformer_dataset.py
@@ -1,0 +1,27 @@
+"""
+Unit tests for ../transformer_dataset.py
+"""
+
+import os
+
+import pylearn2
+from pylearn2.blocks import Block
+from pylearn2.datasets.csv_dataset import CSVDataset
+from pylearn2.datasets.transformer_dataset import TransformerDataset
+
+
+def test_transformer_iterator():
+    """
+    Tests whether TransformerIterator is iterable
+    """
+
+    test_path = os.path.join(pylearn2.__path__[0],
+                             'datasets', 'tests', 'test.csv')
+    raw = CSVDataset(path=test_path, expect_headers=False)
+    block = Block()
+    dataset = TransformerDataset(raw, block)
+    iterator = dataset.iterator('shuffled_sequential', 3)
+    try:
+        iter(iterator)
+    except TypeError:
+        assert False, "TransformerIterator isn't iterable"

--- a/pylearn2/datasets/transformer_dataset.py
+++ b/pylearn2/datasets/transformer_dataset.py
@@ -9,6 +9,8 @@ __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
+from theano.compat.six import Iterator
+
 from pylearn2.datasets.dataset import Dataset
 from pylearn2.space import CompositeSpace
 from pylearn2.utils.data_specs import is_flat_specs
@@ -183,7 +185,7 @@ class TransformerDataset(Dataset):
         return self.raw.get_num_examples()
 
 
-class TransformerIterator(object):
+class TransformerIterator(Iterator):
 
     """
     .. todo::
@@ -211,7 +213,7 @@ class TransformerIterator(object):
         """
         return self
 
-    def next(self):
+    def __next__(self):
         """
         .. todo::
 

--- a/pylearn2/devtools/convert_pkl.py
+++ b/pylearn2/devtools/convert_pkl.py
@@ -1,0 +1,18 @@
+"""
+Convert a .pkl from Python 2 to Python 3
+"""
+
+import pickle
+import sys
+
+
+if __name__ == "__main__":
+    source_pkl = sys.argv[1]
+    try:
+        target_pkl = sys.argv[2]
+    except IndexError:
+        target_pkl = source_pkl
+    with open(source_pkl, 'rb') as f:
+        obj = pickle.load(f, encoding='latin-1')
+    with open(target_pkl, 'wb') as f:
+        pickle.dump(obj, f)

--- a/pylearn2/devtools/run_pyflakes.py
+++ b/pylearn2/devtools/run_pyflakes.py
@@ -16,7 +16,11 @@ __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 __email__ = "pylearn-dev@googlegroups"
 
+import sys
 import logging
+
+from theano.compat import six
+
 from pylearn2.devtools.list_files import list_files
 from pylearn2.utils.shell import run_shell_command
 
@@ -24,7 +28,7 @@ from pylearn2.utils.shell import run_shell_command
 logger = logging.getLogger(__name__)
 
 
-def run_pyflakes(no_warnings = False):
+def run_pyflakes(no_warnings=False):
     """
     Return a description of all errors pyflakes finds in Pylearn2.
 
@@ -47,15 +51,16 @@ def run_pyflakes(no_warnings = False):
 
     for filepath in files:
         output, rc = run_shell_command('pyflakes ' + filepath)
-        if 'pyflakes: not found' in output:
+        output = output.decode(sys.getdefaultencoding())
+        if u'pyflakes: not found' in output:
             # The return code alone does not make it possible to detect
             # if pyflakes is present or not. When pyflakes is not present,
             # the return code seems to always be 127, but 127 can also be
             # the result of finding 127 warnings in a file.
             # Therefore, we examine the output instead.
             raise RuntimeError("Couldn't run 'pyflakes " + filepath + "'. "
-                    "Error code returned:" + str(rc)\
-                    + " Output was: " + output)
+                               "Error code returned:" + str(rc) +
+                               " Output was: " + output)
 
         output = _filter(output, no_warnings)
 
@@ -63,6 +68,7 @@ def run_pyflakes(no_warnings = False):
             rval[filepath] = output
 
     return rval
+
 
 def _filter(output, no_warnings):
     """
@@ -86,33 +92,31 @@ def _filter(output, no_warnings):
     """
     lines = output.split('\n')
 
-    lines = [ line for line in lines if line != '' ]
-
+    lines = [line for line in lines
+             if line != '' and line.find("undefined name 'long'") == -1]
 
     if no_warnings:
 
-        lines = [ line for line in lines if
-                line.find("is assigned to but never used") == -1 ]
+        lines = [line for line in lines if
+                 line.find("is assigned to but never used") == -1]
 
-        lines = [ line for line in lines if
-                line.find('imported but unused') == -1 ]
+        lines = [line for line in lines if
+                 line.find('imported but unused') == -1]
 
-        lines = [ line for line in lines if
-                line.find('redefinition of unused ') == -1 ]
-
+        lines = [line for line in lines if
+                 line.find('redefinition of unused ') == -1]
 
     if len(lines) == 0:
         return None
     return '\n'.join(lines)
 
 if __name__ == '__main__':
-    import sys
     if len(sys.argv) > 1:
         no_warnings = bool(sys.argv[1])
     else:
         no_warnings = False
 
-    d = run_pyflakes( no_warnings = no_warnings)
+    d = run_pyflakes(no_warnings=no_warnings)
 
     for key in d:
         logger.info('{0}:'.format(key))

--- a/pylearn2/devtools/tests/docscrape.py
+++ b/pylearn2/devtools/tests/docscrape.py
@@ -8,7 +8,6 @@ import inspect
 from nose.plugins.skip import SkipTest
 import re
 import sys
-import types
 
 from theano.compat import six
 
@@ -132,7 +131,7 @@ class NumpyDocString(object):
         return self._parsed_data[key]
 
     def __setitem__(self,key,val):
-        if not self._parsed_data.has_key(key):
+        if key not in self._parsed_data:
             raise ValueError("Unknown section %s" % key)
         else:
             self._parsed_data[key] = val
@@ -779,7 +778,9 @@ def docstring_errors(filename, global_dict=None):
     if '__doc__' not in global_dict:
         global_dict['__doc__'] = None
     try:
-        execfile(filename, global_dict)
+        with open(filename) as f:
+            code = compile(f.read(), filename, 'exec')
+            exec(code, global_dict)
     except SystemExit:
         pass
     except SkipTest:

--- a/pylearn2/devtools/tests/test_format.py
+++ b/pylearn2/devtools/tests/test_format.py
@@ -734,7 +734,7 @@ def verify_format_docstrings():
             continue
         try:
             format_infractions.extend(docstring_errors(path))
-        except StandardError as e:
+        except Exception as e:
             format_infractions.append(["%s failed to run so format cannot "
                                        "be checked. Error message:\n %s" %
                                        (rel_path, e)])

--- a/pylearn2/expr/nnet.py
+++ b/pylearn2/expr/nnet.py
@@ -163,7 +163,7 @@ def kl(Y, Y_hat, batch_axis):
 
     total = term_1 + term_2
     naxes = total.ndim
-    axes_to_reduce = range(naxes)
+    axes_to_reduce = list(range(naxes))
     del axes_to_reduce[batch_axis]
     ave = total.mean(axis=axes_to_reduce)
 

--- a/pylearn2/expr/probabilistic_max_pooling.py
+++ b/pylearn2/expr/probabilistic_max_pooling.py
@@ -624,7 +624,7 @@ def max_pool_channels_python(z, pool_size, top_down=None):
     if top_down is None:
         top_down = p.copy()
 
-    for i in xrange(0, n / pool_size):
+    for i in xrange(0, n // pool_size):
         pt = np.exp(z[:, i*pool_size:(i+1)*pool_size])
         off_pt = np.exp(-top_down[:, i])
         denom = pt.sum(axis=1) + off_pt

--- a/pylearn2/expr/tests/test_normalize.py
+++ b/pylearn2/expr/tests/test_normalize.py
@@ -33,7 +33,7 @@ def ground_truth_normalize_row(row, k, n, alpha, beta):
     for i in xrange(row.shape[0]):
         s = k
         tot = 0
-        for j in xrange(max(0,i-n/2), min(row.shape[0],i+n/2+1)):
+        for j in xrange(max(0, i-n//2), min(row.shape[0], i+n//2+1)):
             tot += 1
             sq = row[j] ** 2.
             assert sq > 0.

--- a/pylearn2/format/target_format.py
+++ b/pylearn2/format/target_format.py
@@ -2,6 +2,7 @@
 from operator import mul
 
 import numpy as np
+from theano.compat.six.moves import reduce
 import theano.sparse
 if theano.sparse.enable_sparse:
     scipy_available = True

--- a/pylearn2/gui/get_weights_report.py
+++ b/pylearn2/gui/get_weights_report.py
@@ -4,6 +4,9 @@
     WRITEME
 """
 import logging
+
+from theano.compat.six.moves import input
+
 from pylearn2.utils import serial
 from pylearn2.gui import patch_viewer
 from pylearn2.config import yaml_parse
@@ -83,7 +86,7 @@ def get_weights_report(model_path=None,
                 logger.info('Which is the weights?')
                 for key in keys:
                     logger.info('\t{0}'.format(key))
-                key = raw_input()
+                key = input()
         else:
             key, = keys
         weights = model[key]

--- a/pylearn2/linear/matrixmul.py
+++ b/pylearn2/linear/matrixmul.py
@@ -136,12 +136,12 @@ def make_local_rfs(dataset, nhid, rf_shape, stride, irange = .05,
         filters_per_rf = nhid / total_rfs
 
         idx = 0
-        for r in xrange(num_row_steps):
+        for r in xrange(int(num_row_steps)):
             rc = r * stride[0]
-            for c in xrange(num_col_steps):
+            for c in xrange(int(num_col_steps)):
                 cc = c * stride[1]
 
-                for i in xrange(filters_per_rf):
+                for i in xrange(int(filters_per_rf)):
 
                     if draw_patches:
                         img = dataset.get_batch_topo(1)[0]

--- a/pylearn2/models/autoencoder.py
+++ b/pylearn2/models/autoencoder.py
@@ -9,7 +9,7 @@ import operator
 import numpy
 import theano
 from theano import tensor
-from theano.compat.six.moves import zip as izip
+from theano.compat.six.moves import zip as izip, reduce
 
 # Local imports
 from pylearn2.blocks import Block, StackedBlocks

--- a/pylearn2/models/dbm/__init__.py
+++ b/pylearn2/models/dbm/__init__.py
@@ -15,6 +15,7 @@ __credits__ = ["Ian Goodfellow"]
 __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 
+import collections
 import logging
 import numpy as np
 import sys
@@ -221,7 +222,7 @@ def flatten(l):
     -------
     WRITEME
     """
-    if isinstance(l, (list, tuple)):
+    if isinstance(l, (list, tuple, collections.ValuesView)):
         rval = []
         for elem in l:
             if isinstance(elem, (list, tuple)):

--- a/pylearn2/models/dbm/dbm.py
+++ b/pylearn2/models/dbm/dbm.py
@@ -9,10 +9,10 @@ __maintainer__ = "LISA Lab"
 
 import functools
 import logging
+import operator
 import numpy as np
-import warnings
 
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import reduce, xrange
 from theano import tensor as T, config
 
 from pylearn2.compat import OrderedDict
@@ -138,7 +138,7 @@ class DBM(Model):
 
         assert len(terms) > 0
 
-        rval = reduce(lambda x, y: x + y, terms)
+        rval = reduce(operator.add, terms)
 
         assert rval.ndim == 1
         return rval
@@ -204,7 +204,7 @@ class DBM(Model):
 
         assert len(terms) > 0
 
-        rval = reduce(lambda x, y: x + y, terms)
+        rval = reduce(operator.add, terms)
 
         assert rval.ndim == 1
         return rval
@@ -447,8 +447,6 @@ class DBM(Model):
 
         states = [layer.make_state(num_examples, rng) for layer in layers]
 
-        zipped = safe_zip(layers, states)
-
         def recurse_check(layer, state):
             if isinstance(state, (list, tuple)):
                 for elem in state:
@@ -461,10 +459,10 @@ class DBM(Model):
                                      str(m) + " examples in some component."
                                      "We requested " + str(num_examples))
 
-        for layer, state in zipped:
+        for layer, state in safe_zip(layers, states):
             recurse_check(layer, state)
 
-        rval = OrderedDict(zipped)
+        rval = OrderedDict(safe_zip(layers, states))
 
         return rval
 

--- a/pylearn2/models/dbm/ising.py
+++ b/pylearn2/models/dbm/ising.py
@@ -29,10 +29,13 @@ __credits__ = ["Ian Goodfellow"]
 __license__ = "3-clause BSD"
 __maintainer__ = "LISA Lab"
 
+import operator
+
 import numpy as np
 
 from theano import function
 from theano.gof.op import get_debug_values
+from theano.compat.six.moves import reduce
 from theano.compile.sharedvalue import SharedVariable
 import theano.tensor as T
 import warnings
@@ -683,7 +686,7 @@ class IsingHidden(HiddenLayer):
                         raise ValueError("self.dbm.batch_size is %d but got " +
                                          "shape of %d" % (self.dbm.batch_size,
                                                           sb.shape[0]))
-                    assert reduce(lambda x, y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below,
                                                      self.desired_space)
@@ -753,7 +756,7 @@ class IsingHidden(HiddenLayer):
                         raise ValueError("self.dbm.batch_size is %d but got " +
                                          "shape of %d" % (self.dbm.batch_size,
                                                           sb.shape[0]))
-                    assert reduce(lambda x, y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below,
                                                      self.desired_space)
@@ -1758,7 +1761,7 @@ class BoltzmannIsingHidden(HiddenLayer):
                         raise ValueError("self.dbm.batch_size is %d but got " +
                                          "shape of %d" % (self.dbm.batch_size,
                                                           sb.shape[0]))
-                    assert reduce(lambda x, y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below,
                                                      self.desired_space)
@@ -1824,7 +1827,7 @@ class BoltzmannIsingHidden(HiddenLayer):
                         raise ValueError("self.dbm.batch_size is %d but got " +
                                          "shape of %d" % (self.dbm.batch_size,
                                                           sb.shape[0]))
-                    assert reduce(lambda x, y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below,
                                                      self.desired_space)

--- a/pylearn2/models/dbm/layer.py
+++ b/pylearn2/models/dbm/layer.py
@@ -12,7 +12,8 @@ __maintainer__ = "LISA Lab"
 import functools
 import logging
 import numpy as np
-from theano.compat.six.moves import xrange
+import operator
+from theano.compat.six.moves import input, reduce, xrange
 import time
 import warnings
 
@@ -1345,7 +1346,7 @@ class BinaryVectorMaxPool(HiddenLayer):
                 for sb in get_debug_values(state_below):
                     if sb.shape[0] != self.dbm.batch_size:
                         raise ValueError("self.dbm.batch_size is %d but got shape of %d" % (self.dbm.batch_size, sb.shape[0]))
-                    assert reduce(lambda x,y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below, self.desired_space)
 
@@ -1410,7 +1411,7 @@ class BinaryVectorMaxPool(HiddenLayer):
                 for sb in get_debug_values(state_below):
                     if sb.shape[0] != self.dbm.batch_size:
                         raise ValueError("self.dbm.batch_size is %d but got shape of %d" % (self.dbm.batch_size, sb.shape[0]))
-                    assert reduce(lambda x,y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below, self.desired_space)
 
@@ -2052,7 +2053,7 @@ class GaussianVisLayer(VisibleLayer):
             self.space = Conv2DSpace(shape=[rows,cols], num_channels=channels, axes=axes)
             # To make GaussianVisLayer compatible with any axis ordering
             self.batch_axis=list(axes).index('b')
-            self.axes_to_sum = range(len(axes))
+            self.axes_to_sum = list(range(len(axes)))
             self.axes_to_sum.remove(self.batch_axis)
         else:
             assert rows is None
@@ -3524,7 +3525,7 @@ class BVMP_Gaussian(BinaryVectorMaxPool):
         W ,= self.transformer.get_params()
         W = W.get_value()
 
-        x = raw_input("multiply by beta?")
+        x = input("multiply by beta?")
         if x == 'y':
             beta = self.input_layer.beta.get_value()
             return (W.T * beta).T
@@ -3684,7 +3685,7 @@ class BVMP_Gaussian(BinaryVectorMaxPool):
                 for sb in get_debug_values(state_below):
                     if sb.shape[0] != self.dbm.batch_size:
                         raise ValueError("self.dbm.batch_size is %d but got shape of %d" % (self.dbm.batch_size, sb.shape[0]))
-                    assert reduce(lambda x,y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below, self.desired_space)
 
@@ -3761,7 +3762,7 @@ class BVMP_Gaussian(BinaryVectorMaxPool):
                 for sb in get_debug_values(state_below):
                     if sb.shape[0] != self.dbm.batch_size:
                         raise ValueError("self.dbm.batch_size is %d but got shape of %d" % (self.dbm.batch_size, sb.shape[0]))
-                    assert reduce(lambda x,y: x * y, sb.shape[1:]) == self.input_dim
+                    assert reduce(operator.mul, sb.shape[1:]) == self.input_dim
 
             state_below = self.input_space.format_as(state_below, self.desired_space)
 
@@ -4069,7 +4070,7 @@ class CompositeLayer(HiddenLayer):
         logger.info('Get topological weights for which layer?')
         for i, component in enumerate(self.components):
             logger.info('{0} {1}'.format(i, component.layer_name))
-        x = raw_input()
+        x = input()
         return self.components[int(x)].get_weights_topo()
 
     def get_monitoring_channels_from_state(self, state):

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -9,11 +9,13 @@ __maintainer__ = "LISA Lab"
 
 import logging
 import math
+import operator
 import sys
 import warnings
 
 import numpy as np
-from theano.compat.six.moves import xrange
+from theano.compat import six
+from theano.compat.six.moves import reduce, xrange
 from theano import config
 from theano.gof.op import get_debug_values
 from theano.sandbox.rng_mrg import MRG_RandomStreams
@@ -73,8 +75,13 @@ logger.debug("MLP changing the recursion limit.")
 # precisely when you're going to exceed the stack segment.
 sys.setrecursionlimit(40000)
 
+if six.PY3:
+    LayerBase = six.with_metaclass(RNNWrapper, Model)
+else:
+    LayerBase = Model
 
-class Layer(Model):
+
+class Layer(LayerBase):
 
     """
     Abstract class. A Layer of an MLP.
@@ -677,7 +684,7 @@ class MLP(Layer):
         if len(layer_costs) == 0:
             return T.constant(0, dtype=config.floatX)
 
-        total_cost = reduce(lambda x, y: x + y, layer_costs)
+        total_cost = reduce(operator.add, layer_costs)
 
         return total_cost
 
@@ -696,7 +703,7 @@ class MLP(Layer):
         if len(layer_costs) == 0:
             return T.constant(0, dtype=config.floatX)
 
-        total_cost = reduce(lambda x, y: x + y, layer_costs)
+        total_cost = reduce(operator.add, layer_costs)
 
         return total_cost
 
@@ -3033,15 +3040,19 @@ class ConvElemwise(Layer):
         rng = self.mlp.rng
 
         if self.border_mode == 'valid':
-            output_shape = [(self.input_space.shape[0] - self.kernel_shape[0])
-                            / self.kernel_stride[0] + 1,
-                            (self.input_space.shape[1] - self.kernel_shape[1])
-                            / self.kernel_stride[1] + 1]
+            output_shape = [int((self.input_space.shape[0]
+                                 - self.kernel_shape[0])
+                                / self.kernel_stride[0]) + 1,
+                            int((self.input_space.shape[1]
+                                 - self.kernel_shape[1])
+                                / self.kernel_stride[1]) + 1]
         elif self.border_mode == 'full':
-            output_shape = [(self.input_space.shape[0] + self.kernel_shape[0])
-                            / self.kernel_stride[0] - 1,
-                            (self.input_space.shape[1] + self.kernel_shape[1])
-                            / self.kernel_stride[1] - 1]
+            output_shape = [int((self.input_space.shape[0]
+                                 + self.kernel_shape[0])
+                                / self.kernel_stride[0]) - 1,
+                            int((self.input_space.shape[1]
+                                 + self.kernel_shape[1])
+                                / self.kernel_stride[1]) - 1]
 
         self.detector_space = Conv2DSpace(shape=output_shape,
                                           num_channels=self.output_channels,
@@ -4668,7 +4679,7 @@ def geometric_mean_prediction(forward_props):
         assert isinstance(out.owner.op, T.nnet.Softmax)
         assert len(out.owner.inputs) == 1
         presoftmax.append(out.owner.inputs[0])
-    average = reduce(lambda x, y: x + y, presoftmax) / float(len(presoftmax))
+    average = reduce(operator.add, presoftmax) / float(len(presoftmax))
     return T.nnet.softmax(average)
 
 

--- a/pylearn2/models/pca.py
+++ b/pylearn2/models/pca.py
@@ -864,9 +864,9 @@ if __name__ == "__main__":
     data = load_data({'dataset': args.dataset})
     # TODO: this can be done more efficiently and readably by list
     # comprehensions
-    train_data, valid_data, test_data = map(lambda(x):
+    train_data, valid_data, test_data = map(lambda x:
                                             x.get_value(borrow=True), data)
-    logger.info("Dataset shapes: {0}".format(map(lambda(x):
+    logger.info("Dataset shapes: {0}".format(map(lambda x:
                                              x.get_value().shape, data)))
     # PCA base-class constructor arguments.
     conf = {

--- a/pylearn2/models/rbm.py
+++ b/pylearn2/models/rbm.py
@@ -1471,7 +1471,7 @@ class _SGDOptimizer(_Optimizer):
         # Check that no ..._clip keyword is being ignored
         for clip_name in clip_names_seen:
             kwargs.pop(clip_name)
-        for kw in kwargs.iterkeys():
+        for kw in six.iterkeys(kwargs):
             if kw[-5:] == '_clip':
                 logger.warning('In SGDOptimizer, keyword argument {0} '
                                'will be ignored, because no parameter '
@@ -1521,7 +1521,7 @@ class _SGDOptimizer(_Optimizer):
         for lr_name in lr_names_seen:
             if lr_name in kwargs:
                 kwargs.pop(lr_name)
-        for kw in kwargs.iterkeys():
+        for kw in six.iterkeys(kwargs):
             if kw[-3:] == '_lr':
                 logger.warning('In SGDOptimizer, keyword argument {0} '
                                'will be ignored, because no parameter '

--- a/pylearn2/models/s3c.py
+++ b/pylearn2/models/s3c.py
@@ -13,7 +13,7 @@ import time
 import warnings
 
 import numpy as np
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import input, xrange
 from theano import config, function
 from theano import scan
 from theano.gof.op import get_debug_values, debug_error_message, debug_assert
@@ -1565,7 +1565,7 @@ class S3C(Model, Block):
 
         W = self.W.get_value()
 
-        x = raw_input('multiply weights by mu? (y/n) ')
+        x = input('multiply weights by mu? (y/n) ')
 
         if x == 'y':
             return W * self.mu.get_value()

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -4,7 +4,7 @@ from itertools import product
 
 import numpy as np
 from theano.compat import six
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import reduce, xrange
 import theano
 from theano import tensor, config
 from nose.tools import assert_raises

--- a/pylearn2/monitor.py
+++ b/pylearn2/monitor.py
@@ -421,11 +421,12 @@ class Monitor(object):
                 mode.record.handle_line('compiling monitor including ' +
                                         'channel ' + key + '\n')
             log.info('\t%s' % key)
-        it = [d.iterator(mode=i, num_batches=n, batch_size=b,
-                         data_specs=self._flat_data_specs,
-                         return_tuple=True)
-              for d, i, n, b in safe_izip(self._datasets, self._iteration_mode,
-                                          self._num_batches, self._batch_size)]
+        it = []
+        for d, i, n, b in safe_izip(self._datasets, self._iteration_mode,
+                                    self._num_batches, self._batch_size):
+            it.append(d.iterator(mode=i, num_batches=n, batch_size=b,
+                                 data_specs=self._flat_data_specs,
+                                 return_tuple=True))
         self.num_examples = [np.cast[config.floatX](float(i.num_examples))
                              for i in it]
         givens = [OrderedDict() for d in self._datasets]
@@ -613,7 +614,7 @@ class Monitor(object):
         if six.PY3:
             numeric = (float, int)
         else:
-            numeric = (float, int, long)
+            numeric = (float, int, long)  # noqa
 
         if isinstance(val, numeric):
             val = np.cast[theano.config.floatX](val)

--- a/pylearn2/packaged_dependencies/theano_linear/linear.py
+++ b/pylearn2/packaged_dependencies/theano_linear/linear.py
@@ -6,6 +6,9 @@
 import numpy
 import theano
 from theano import tensor
+from theano.compat.six.moves import reduce
+
+from pylearn2.utils import py_integer_types
 
 prod = numpy.prod
 
@@ -228,7 +231,7 @@ class LinearTransform(object):
         else:
             # R1 R2 C1 C2 C3 -> C1 C2 C3 R1 R2
             ss = x.ndim - len(cshp)
-        pattern = range(ss, x.ndim) + range(ss)
+        pattern = list(range(ss, x.ndim)) + list(range(ss))
         return x.transpose(pattern)
 
     def transpose_right(self, x, T):
@@ -245,7 +248,7 @@ class LinearTransform(object):
         else:
             # R1 C1 C2 -> C1 C2 R1
             ss = x.ndim - len(rshp)
-        pattern = range(ss, x.ndim) + range(ss)
+        pattern = list(range(ss, x.ndim)) + list(range(ss))
         return x.transpose(pattern)
 
     def split_left_shape(self, xshp, T):
@@ -561,12 +564,13 @@ if use_concat_class: # needs to be brought up to date with LinearTransform metho
         def __init__(self, Wlist, col_shape=None):
             super(Concat, self).__init__([])
             self._Wlist = list(Wlist)
-            if not isinstance(col_shape, (int, long, numpy.integer, tuple, type(None))):
+            if not (isinstance(col_shape, py_integer_types)
+                    or isinstance(col_shape, (tuple, type(None)))):
                 raise TypeError('col_shape must be int or int tuple')
             self._col_sizes = [prod(w.col_shape()) for w in Wlist]
             if col_shape is None:
                 self.__col_shape = sum(self._col_sizes),
-            elif isinstance(col_shape, (int, long, numpy.integer)):
+            elif isinstance(col_shape, py_integer_types):
                 self.__col_shape = col_shape,
             else:
                 self.__col_shape = tuple(col_shape)

--- a/pylearn2/packaged_dependencies/theano_linear/spconv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/spconv.py
@@ -15,7 +15,6 @@ from theano.compat.six.moves import xrange
 import theano
 import theano.sparse
 from theano import sparse, gof, Op, tensor
-from theano.printing import Print
 
 raise ImportError("THIS OLD CODE'S TESTS ARE BIT-ROTTEN")
 
@@ -234,12 +233,14 @@ class Remove0(Op):
         """
         return gof.Apply(self, [x], [x.type()])
 
-    def perform(self,node, (x,), (z,)):
+    def perform(self,node, xs, zs):
         """
         .. todo::
 
             WRITEME
         """
+        x = xs[0]
+        z = zs[0]
         if x.format != 'csc':
             raise TypeError('Remove0 only works on csc matrices')
 
@@ -263,13 +264,13 @@ class Remove0(Op):
 
         z[0] = sparse.csc_matrix((new_data, new_indices, new_indptr), (M,N))
 
-    def grad(self, (x,), (gz,)):
+    def grad(self, x, gz):
         """
         .. todo::
 
             WRITEME
         """
-        return [gz]
+        return [gz[0]]
 
 remove0 = Remove0()
 
@@ -296,21 +297,21 @@ class EnsureSortedIndices(Op):
         """
         return gof.Apply(self, [x], [x.type()])
 
-    def perform(self,node, (x,), (z,)):
+    def perform(self,node, xs, zs):
         """
         .. todo::
 
             WRITEME
         """
-        z[0] = x.ensure_sorted_indices(inplace=self.inplace)
+        zs[0][0] = xs[0].ensure_sorted_indices(inplace=self.inplace)
 
-    def grad(self, (x,), (gz,)):
+    def grad(self, xs, gz):
         """
         .. todo::
 
             WRITEME
         """
-        return [gz]
+        return [gz[0]]
 
 ensure_sorted_indices = EnsureSortedIndices(inplace=False)
 
@@ -394,14 +395,15 @@ class ConvolutionIndices(Op):
     """
 
     @staticmethod
-    def sparse_eval(inshp, kshp, nkern, (dx,dy)=(1,1), mode='valid'):
+    def sparse_eval(inshp, kshp, nkern, offset=(1, 1), mode='valid'):
         """
         .. todo::
 
             WRITEME
         """
         # STALE
-        return convolution_indices.evaluate(inshp,kshp,(dx,dy),nkern,mode=mode,ws=False)
+        return convolution_indices.evaluate(inshp, kshp, offset, nkern,
+                                            mode=mode, ws=False)
 
     @staticmethod
     def conv_eval(IR, IC, KR, KC, C, subsample=(1,1), mode='valid'):
@@ -415,7 +417,7 @@ class ConvolutionIndices(Op):
 
     # img_shape and ker_shape are (height,width)
     @staticmethod
-    def evaluate(imshp,kshp, (dx,dy)=(1,1), nkern=1, mode='valid', ws=True):
+    def evaluate(imshp, kshp, offset=(1, 1), nkern=1, mode='valid', ws=True):
         """
         Build a sparse matrix which can be used for performing...
         * convolution: in this case, the dot product of this matrix with the
@@ -437,7 +439,7 @@ class ConvolutionIndices(Op):
             'full' full convolution obtained by zero-padding the input
         ws : bool
             True if weight sharing, False otherwise
-        (dx,dy) : tuple of int
+        offset : tuple of int
             Offset parameter. In the case of no weight sharing, gives the \
             pixel offset between two receptive fields. With weight sharing \
             gives the offset between the top-left pixels of the generated \
@@ -450,6 +452,7 @@ class ConvolutionIndices(Op):
             the image which will be the result of filtering.
         """
         N = numpy
+        dx, dy = offset
 
         # inshp contains either 2 entries (height,width) or 3 (nfeatures,h,w)
         # in the first case, default nfeatures to 1
@@ -579,13 +582,15 @@ class ConvolutionIndices(Op):
 
         return rval
 
-    def perform(self, node, (inshp, kshp),\
-                (out_indices, out_indptr, spmat_shape)):
+    def perform(self, node, shape, out):
         """
         .. todo::
 
             WRITEME
         """
+        inshp, kshp = shape
+        out_indices, out_indptr, spmat_shape = out
+
         indices, indptr, spmatshp, outshp = self.evaluate(inshp, kshp)
         out_indices[0] = indices
         out_indptr[0] = indptr

--- a/pylearn2/packaged_dependencies/theano_linear/test_matrixmul.py
+++ b/pylearn2/packaged_dependencies/theano_linear/test_matrixmul.py
@@ -10,7 +10,7 @@ from .linear import dot_shape_from_shape
 from .linear import dot
 
 def assert_compute_equal(outputs, inputs=[]):
-    outputs = map(tensor.as_tensor_variable, outputs)
+    outputs = [tensor.as_tensor_variable(o) for o in outputs]
     f = theano.function(inputs, outputs)
     outvals = f()
     assert all(numpy.all(outvals[i] == outvals[0])
@@ -18,7 +18,7 @@ def assert_compute_equal(outputs, inputs=[]):
 
 
 def assert_compute_allclose(outputs, inputs=[]):
-    outputs = map(tensor.as_tensor_variable, outputs)
+    outputs = [tensor.as_tensor_variable(o) for o in outputs]
     f = theano.function(inputs, outputs)
     outvals = f()
     assert all(numpy.allclose(outvals[i], outvals[0])

--- a/pylearn2/sandbox/rnn/space/__init__.py
+++ b/pylearn2/sandbox/rnn/space/__init__.py
@@ -103,6 +103,9 @@ class SequenceDataSpace(space.SimplyTypedSpace):
             return False
         return self.space == other.space
 
+    def __hash__(self):
+        return hash(self.space)
+
     def __str__(self):
         return '%s(%s)' % (self.__class__.__name__, self.space)
 
@@ -230,6 +233,9 @@ class SequenceMaskSpace(space.SimplyTypedSpace):
 
     def __eq__(self, other):
         return isinstance(other, SequenceMaskSpace)
+
+    def __hash__(self):
+        return 1
 
     def __str__(self):
         return '%s' % (self.__class__.__name__)

--- a/pylearn2/scripts/datasets/step_through_norb_foveated.py
+++ b/pylearn2/scripts/datasets/step_through_norb_foveated.py
@@ -7,6 +7,8 @@ and its label.
 """
 import numpy as np
 
+from theano.compat.six.moves import input
+
 from pylearn2.datasets.norb_small import FoveatedNORB
 from pylearn2.gui.patch_viewer import PatchViewer
 from pylearn2.utils import get_choice
@@ -30,8 +32,8 @@ while True:
     patch = topo[i, :, :, :]
     patch = patch / np.abs(patch).max()
 
-    pv.add_patch(patch[:,:,1], rescale=False)
-    pv.add_patch(patch[:,:,0], rescale=False)
+    pv.add_patch(patch[:, :, 1], rescale=False)
+    pv.add_patch(patch[:, :, 0], rescale=False)
 
     pv.show()
 
@@ -51,4 +53,4 @@ while True:
         i += 1
 
     if choice == 'g':
-        i = int(raw_input('index: '))
+        i = int(input('index: '))

--- a/pylearn2/scripts/dbm/show_reconstructions.py
+++ b/pylearn2/scripts/dbm/show_reconstructions.py
@@ -18,7 +18,7 @@ from pylearn2.utils import serial
 import sys
 from pylearn2.config import yaml_parse
 from pylearn2.gui.patch_viewer import PatchViewer
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import input, xrange
 from theano import function
 
 rows = 5
@@ -37,7 +37,7 @@ dataset_yaml_src = model.dataset_yaml_src
 print('Loading data...')
 dataset = yaml_parse.load(dataset_yaml_src)
 
-x = raw_input('use test set? (y/n) ')
+x = input('use test set? (y/n) ')
 
 if x == 'y':
     dataset = dataset.get_test_set()
@@ -130,7 +130,7 @@ while True:
     show()
     print('Displaying reconstructions. (q to quit, ENTER = show more)')
     while True:
-        x = raw_input()
+        x = input()
         if x == 'q':
             quit()
         if x == '':

--- a/pylearn2/scripts/dbm/show_samples.py
+++ b/pylearn2/scripts/dbm/show_samples.py
@@ -20,7 +20,7 @@ import sys
 from pylearn2.config import yaml_parse
 from pylearn2.gui.patch_viewer import PatchViewer
 import time
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import input, xrange
 from theano import function
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 import numpy as np
@@ -160,7 +160,7 @@ print('Sampling function compilation took',t2-t1)
 while True:
     print('Displaying samples. How many steps to take next? (q to quit, ENTER=1)')
     while True:
-        x = raw_input()
+        x = input()
         if x == 'q':
             quit()
         if x == '':

--- a/pylearn2/scripts/jobman/tester.py
+++ b/pylearn2/scripts/jobman/tester.py
@@ -12,8 +12,13 @@ website)
 
 """
 
-from jobman.tools import DD, flatten
-from jobman import api0, sql
+from nose.plugins.skip import SkipTest
+try:
+    from jobman.tools import DD, flatten
+    from jobman import api0, sql
+except ImportError:
+    raise SkipTest()
+
 
 from pylearn2.scripts.jobman import experiment
 

--- a/pylearn2/scripts/papers/maxout/compute_test_err.py
+++ b/pylearn2/scripts/papers/maxout/compute_test_err.py
@@ -44,7 +44,7 @@ assert test.X.shape[0] % batch_size == 0
 
 def accs():
     mf1_accs = []
-    assert isinstance(test.X.shape[0], (int, long))
+    assert isinstance(test.X.shape[0], py_integer_types)
     assert isinstance(batch_size, py_integer_types)
     iterator = test.iterator(mode = 'even_sequential',
                             batch_size = batch_size,

--- a/pylearn2/scripts/pkl_inspector.py
+++ b/pylearn2/scripts/pkl_inspector.py
@@ -7,7 +7,10 @@ from __future__ import print_function
 
 import sys
 from pylearn2.utils import serial
-import cPickle
+try:
+    import cPickle
+except ImportError:
+    import pickle as cPickle
 import pickle
 import time
 from theano.printing import min_informative_str

--- a/pylearn2/scripts/plot_monitor.py
+++ b/pylearn2/scripts/plot_monitor.py
@@ -22,7 +22,7 @@ import gc
 import numpy as np
 import sys
 
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import input, xrange
 from pylearn2.utils import serial
 from theano.printing import _TagGenerator
 from pylearn2.utils.string_utils import number_aware_alphabetical_key
@@ -142,14 +142,14 @@ def main():
 
             print("Put e, b, s or h in the list somewhere to plot " + 
                     "epochs, batches, seconds, or hours, respectively.")
-            response = raw_input('Enter a list of channels to plot ' + \
+            response = input('Enter a list of channels to plot ' + \
                     '(example: A, C,F-G, h, <test_err>) or q to quit' + \
                     ' or o for options: ')
 
             if response == 'o':
                 print('1: smooth all channels')
                 print('any other response: do nothing, go back to plotting')
-                response = raw_input('Enter your choice: ')
+                response = input('Enter your choice: ')
                 if response == '1':
                     for channel in channels.values():
                         k = 5

--- a/pylearn2/space/tests/test_space.py
+++ b/pylearn2/space/tests/test_space.py
@@ -465,11 +465,11 @@ def test_dtypes():
             except TypeError as ex:
                 assert dtype_is_none_msg in str(ex)
             except Exception as unexpected_ex:
-                print ("Expected an exception of type TypeError with message "
-                       "%s, got a %s instead with message %s." %
-                       (dtype_is_none_msg,
-                        type(unexpected_ex),
-                        str(unexpected_ex)))
+                print("Expected an exception of type TypeError with message "
+                      "%s, got a %s instead with message %s." %
+                      (dtype_is_none_msg,
+                       type(unexpected_ex),
+                       str(unexpected_ex)))
                 raise unexpected_ex
             finally:
                 return
@@ -486,11 +486,11 @@ def test_dtypes():
             except TypeError as ex:
                 assert dtype_is_none_msg in str(ex)
             except Exception as unexpected_ex:
-                print ("Expected an exception of type TypeError with message "
-                       "%s, got a %s instead with message %s." %
-                       (dtype_is_none_msg,
-                        type(unexpected_ex),
-                        str(unexpected_ex)))
+                print("Expected an exception of type TypeError with message "
+                      "%s, got a %s instead with message %s." %
+                      (dtype_is_none_msg,
+                       type(unexpected_ex),
+                       str(unexpected_ex)))
                 raise unexpected_ex
             finally:
                 return
@@ -520,11 +520,11 @@ def test_dtypes():
             except TypeError as ex:
                 assert dtype_is_none_msg in str(ex)
             except Exception as unexpected_ex:
-                print ("Expected an exception of type TypeError with message "
-                       "%s, got a %s instead with message %s." %
-                       (dtype_is_none_msg,
-                        type(unexpected_ex),
-                        str(unexpected_ex)))
+                print("Expected an exception of type TypeError with message "
+                      "%s, got a %s instead with message %s." %
+                      (dtype_is_none_msg,
+                       type(unexpected_ex),
+                       str(unexpected_ex)))
                 raise unexpected_ex
             finally:
                 return

--- a/pylearn2/tests/test_monitor.py
+++ b/pylearn2/tests/test_monitor.py
@@ -214,7 +214,8 @@ def test_revisit():
 
     for mon_batch_size in xrange(BATCH_SIZE, MAX_BATCH_SIZE + 1,
             BATCH_SIZE_STRIDE):
-        for num_mon_batches in [ 1, 3, num_examples / mon_batch_size, None ]:
+        nums = [1, 3, int(num_examples / mon_batch_size), None]
+        for num_mon_batches in nums:
             for mode in sorted(_iteration_schemes):
 
                 if num_mon_batches is None and mode in ['random_uniform', 'random_slice']:
@@ -243,8 +244,8 @@ def test_revisit():
                     num_mon_batches = int(np.ceil(float(num_examples) /
                                           float(mon_batch_size)))
 
-                batches = [ None ] * num_mon_batches
-                visited = [ False ] * num_mon_batches
+                batches = [None] * int(num_mon_batches)
+                visited = [False] * int(num_mon_batches)
 
                 batch_idx = shared(0)
 

--- a/pylearn2/training_algorithms/bgd.py
+++ b/pylearn2/training_algorithms/bgd.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 from theano import config
 
-from pylearn2.compat import OrderedDict
+from pylearn2.compat import OrderedDict, first_value
 from pylearn2.monitor import Monitor
 from pylearn2.optimization.batch_gradient_descent import BatchGradientDescent
 from pylearn2.utils.iteration import is_stochastic
@@ -149,8 +149,9 @@ class BGD(TrainingAlgorithm):
             if self.set_batch_size:
                 model.set_batch_size(batch_size)
             elif hasattr(model, 'force_batch_size'):
-                if not (model.force_batch_size <= 0 or batch_size ==
-                        model.force_batch_size):
+                if not (model.force_batch_size is None or
+                        model.force_batch_size <= 0 or
+                        batch_size == model.force_batch_size):
                     raise ValueError("batch_size is %d but " +
                                      "model.force_batch_size is %d" %
                                      (batch_size, model.force_batch_size))
@@ -242,19 +243,19 @@ class BGD(TrainingAlgorithm):
                 ipt=None,
                 val=self.optimizer.ave_step_size,
                 data_specs=(NullSpace(), ''),
-                dataset=self.monitoring_dataset.values()[0])
+                dataset=first_value(self.monitoring_dataset))
             self.monitor.add_channel(
                 name='ave_grad_size',
                 ipt=None,
                 val=self.optimizer.ave_grad_size,
                 data_specs=(NullSpace(), ''),
-                dataset=self.monitoring_dataset.values()[0])
+                dataset=first_value(self.monitoring_dataset))
             self.monitor.add_channel(
                 name='ave_grad_mult',
                 ipt=None,
                 val=self.optimizer.ave_grad_mult,
                 data_specs=(NullSpace(), ''),
-                dataset=self.monitoring_dataset.values()[0])
+                dataset=first_value(self.monitoring_dataset))
 
         self.first = True
         self.bSetup = True

--- a/pylearn2/training_algorithms/tests/test_bgd.py
+++ b/pylearn2/training_algorithms/tests/test_bgd.py
@@ -193,7 +193,7 @@ def test_determinism():
                 disturb_mem.disturb_mem()
                 def mlp_pred(non_linearity):
                     Z = [T.dot(X, W) for W in model.W1]
-                    H = map(non_linearity, Z)
+                    H = [non_linearity(z) for z in Z]
                     Z = [T.dot(h, W) for h, W in safe_izip(H, model.W2)]
                     pred = sum(Z)
                     return pred

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1216,7 +1216,7 @@ def test_determinism_2():
 
                 def mlp_pred(non_linearity):
                     Z = [T.dot(X, W) for W in model.W1]
-                    H = map(non_linearity, Z)
+                    H = [non_linearity(z) for z in Z]
                     Z = [T.dot(h, W) for h, W in safe_izip(H, model.W2)]
                     pred = sum(Z)
                     return pred

--- a/pylearn2/training_algorithms/training_algorithm.py
+++ b/pylearn2/training_algorithms/training_algorithm.py
@@ -110,7 +110,7 @@ class TrainingAlgorithm(object):
         """
         batch_size = self.batch_size
         if hasattr(model, "force_batch_size"):
-            if model.force_batch_size > 0:
+            if model.force_batch_size and model.force_batch_size > 0:
                 if batch_size is not None:
                     if batch_size != model.force_batch_size:
                         if self.set_batch_size:

--- a/pylearn2/utils/__init__.py
+++ b/pylearn2/utils/__init__.py
@@ -8,7 +8,7 @@ import warnings
 
 from .general import is_iterable, contains_nan, contains_inf, isfinite
 import theano
-from theano.compat.six.moves import zip as izip
+from theano.compat.six.moves import input, zip as izip
 # Delay import of pylearn2.config.yaml_parse and pylearn2.datasets.control
 # to avoid circular imports
 yaml_parse = None
@@ -220,6 +220,14 @@ class CallbackOp(theano.gof.Op):
         """
         return hash(self.callback)
 
+    def __hash__(self):
+        """
+        .. todo::
+
+            WRITEME
+        """
+        return self.hash()
+
 
 def get_dataless_dataset(model):
     """
@@ -394,8 +402,8 @@ if six.PY3:
     py_integer_types = (int, np.integer)
     py_number_types = (int, float, complex, np.number)
 else:
-    py_integer_types = (int, long, np.integer)
-    py_number_types = (int, long, float, complex, np.number)
+    py_integer_types = (int, long, np.integer)  # noqa
+    py_number_types = (int, long, float, complex, np.number)  # noqa
 
 py_float_types = (float, np.floating)
 py_complex_types = (complex, np.complex)
@@ -429,7 +437,7 @@ def get_choice(choice_to_explanation):
         if not first:
             warnings.warn('unrecognized choice')
         first = False
-        choice = raw_input(prompt)
+        choice = input(prompt)
     return choice
 
 

--- a/pylearn2/utils/bit_strings.py
+++ b/pylearn2/utils/bit_strings.py
@@ -33,5 +33,5 @@ def all_bit_strings(bits, dtype='uint8'):
     Obviously the memory requirements of this are exponential in the first
     argument, so use with caution.
     """
-    return np.array([map(int, np.binary_repr(i, width=bits))
+    return np.array([[int(x) for x in np.binary_repr(i, width=bits)]
                      for i in xrange(0, 2 ** bits)], dtype=dtype)

--- a/pylearn2/utils/compile.py
+++ b/pylearn2/utils/compile.py
@@ -58,11 +58,11 @@ def compiled_theano_function(fn):
     @functools.wraps(fn)
     def wrapped(self):
         try:
-            func = self._compiled_functions[fn.func_name]
+            func = self._compiled_functions[fn.__name__]
         except (AttributeError, KeyError):
             if not hasattr(self, '_compiled_functions'):
                 self._compiled_functions = {}
-            self._compiled_functions[fn.func_name] = func = fn(self)
+            self._compiled_functions[fn.__name__] = func = fn(self)
         return func
     return property(wrapped)
 

--- a/pylearn2/utils/datasets.py
+++ b/pylearn2/utils/datasets.py
@@ -12,7 +12,7 @@ import warnings
 # Third-party imports
 import numpy
 import scipy
-from theano.compat.six.moves import xrange
+from theano.compat.six.moves import reduce, xrange
 import theano
 try:
     from matplotlib import pyplot
@@ -21,7 +21,6 @@ except ImportError:
     warnings.warn("Could not import some dependencies.")
 
 # Local imports
-from pylearn2.utils import sharedX
 from pylearn2.utils.rng import make_np_rng
 
 

--- a/pylearn2/utils/insert_along_axis.py
+++ b/pylearn2/utils/insert_along_axis.py
@@ -158,7 +158,7 @@ class InsertAlongAxis(theano.Op):
         """
         x, new_length, nonconstants = inputs
         d_out = gradients[0]
-        swap = range(self.ndim)
+        swap = list(range(self.ndim))
         swap.remove(self.axis)
         swap.insert(0, self.axis)
         return [d_out.dimshuffle(swap)[nonconstants].dimshuffle(swap),

--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -325,6 +325,9 @@ class ForcedEvenIterator(SubsetIterator):
 
         return batch
 
+    def __next__(self):
+        return self.next()
+
 
 def as_even(iterator_cls):
     """
@@ -413,6 +416,9 @@ class SequentialSubsetIterator(SubsetIterator):
             self._batch += 1
             return self._last
 
+    def __next__(self):
+        return self.next()
+
     fancy = False
     stochastic = False
     uniform_batch_size = False
@@ -473,6 +479,9 @@ class ShuffledSequentialSubsetIterator(SequentialSubsetIterator):
             self._batch += 1
             return rval
 
+    def __next__(self):
+        return self.next()
+
 
 class RandomUniformSubsetIterator(SubsetIterator):
     """
@@ -511,6 +520,9 @@ class RandomUniformSubsetIterator(SubsetIterator):
                                                    size=(self._batch_size,))
             self._next_batch_no += 1
             return self._last
+
+    def __next__(self):
+        return self.next()
 
     fancy = True
     stochastic = True
@@ -554,6 +566,9 @@ class RandomSliceSubsetIterator(RandomUniformSubsetIterator):
             self._last = slice(start, start + self._batch_size)
             self._next_batch_no += 1
             return self._last
+
+    def __next__(self):
+        return self.next()
 
     fancy = False
     stochastic = True
@@ -599,7 +614,7 @@ class BatchwiseShuffledSequentialIterator(SequentialSubsetIterator):
         self._num_batches = int(num_batches)
         self._next_batch_no = 0
         self._idx = 0
-        self._batch_order = range(self._num_batches)
+        self._batch_order = list(range(self._num_batches))
         self._rng.shuffle(self._batch_order)
 
     @wraps(SubsetIterator.next)
@@ -614,6 +629,9 @@ class BatchwiseShuffledSequentialIterator(SequentialSubsetIterator):
                 self._last = slice(start, start + self._batch_size)
             self._next_batch_no += 1
             return self._last
+
+    def __next__(self):
+        return self.next()
 
     fancy = False
     stochastic = True

--- a/pylearn2/utils/logger.py
+++ b/pylearn2/utils/logger.py
@@ -27,6 +27,7 @@ __maintainer__ = "David Warde-Farley"
 import logging
 import sys
 from logging import Handler, Formatter
+from theano.compat import six
 from theano.compat.six.moves import xrange
 
 
@@ -178,7 +179,7 @@ class CustomStreamHandler(Handler):
                 stream = self.stderr
             else:
                 stream = self.stdout
-            fs = "%s\n"
+            fs = u"%s\n"
             #if no unicode support...
             #Python 2.6 don't have logging._unicode, so use the no unicode path
             # as stream.encoding also don't exist.
@@ -186,11 +187,10 @@ class CustomStreamHandler(Handler):
                 stream.write(fs % msg)
             else:
                 try:
-                    if (isinstance(msg, unicode) and
-                        getattr(stream, 'encoding', None)):
-                        ufs = fs.decode(stream.encoding)
+                    if (isinstance(msg, six.text_type) and
+                            getattr(stream, 'encoding', None)):
                         try:
-                            stream.write(ufs % msg)
+                            stream.write(fs % msg)
                         except UnicodeEncodeError:
                             # Printing to terminals sometimes fails. For
                             # example, with an encoding of 'cp1251', the above
@@ -199,11 +199,11 @@ class CustomStreamHandler(Handler):
                             # writing to a terminal even when the codepage is
                             # set to cp1251.  An extra encoding step seems to
                             # be needed.
-                            stream.write((ufs % msg).encode(stream.encoding))
+                            stream.write((fs % msg).encode(stream.encoding))
                     else:
                         stream.write(fs % msg)
-                except UnicodeError:
-                    stream.write(fs % msg.encode("UTF-8"))
+                except (UnicodeError, TypeError):
+                    stream.write((fs % msg).encode("UTF-8"))
             self.flush()
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/pylearn2/utils/serial.py
+++ b/pylearn2/utils/serial.py
@@ -137,10 +137,8 @@ def load(filepath, recurse_depth=0, retry=True):
             logger.info('Max number of tries exceeded while trying to open '
                         '{0}'.format(filepath))
             logger.info('attempting to open via reading string')
-            f = open(filepath, 'rb')
-            lines = f.readlines()
-            f.close()
-            content = ''.join(lines)
+            with open(filepath, 'rb') as f:
+                content = f.read()
             return cPickle.loads(content)
         else:
             nsec = 0.5 * (2.0 ** float(recurse_depth))
@@ -475,7 +473,7 @@ def read_bin_lush_matrix(filepath):
 
     excess = f.read(-1)
 
-    if excess != '':
+    if excess:
         raise ValueError(str(len(excess))+' extra bytes found at end of file.'
                 ' This indicates  mismatch between header and content')
 

--- a/pylearn2/utils/tests/test_mnist_ubyte.py
+++ b/pylearn2/utils/tests/test_mnist_ubyte.py
@@ -1,8 +1,12 @@
 import struct
 import tempfile
+
 import numpy
+from theano.compat import six
+
 from pylearn2.utils.mnist_ubyte import read_mnist_images, read_mnist_labels
 from pylearn2.utils.mnist_ubyte import MNIST_LABEL_MAGIC, MNIST_IMAGE_MAGIC
+
 
 def test_read_labels():
     with tempfile.TemporaryFile() as f:
@@ -17,10 +21,11 @@ def test_read_labels():
         assert arr[2] == 3
         assert arr[3] == 1
 
+
 def test_read_images():
     header = struct.pack('>iiii', MNIST_IMAGE_MAGIC, 4, 3, 2)
-    data =  ('\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00'
-             '\t\x00\x00\x00\x00\x00\x00\xff.\x00\x00\x00\x00\x00')
+    data = six.b('\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00'
+                 '\t\x00\x00\x00\x00\x00\x00\xff.\x00\x00\x00\x00\x00')
     with tempfile.TemporaryFile() as f:
         buf = header + data
         f.write(buf)
@@ -43,5 +48,5 @@ def test_read_images():
         f.seek(0)
         arr = read_mnist_images(f, dtype='bool')
         assert arr.dtype == numpy.dtype('bool')
-        assert arr[2, 2, 1] == True
+        assert arr[2, 2, 1]
         assert (arr == 0).sum() == 23

--- a/pylearn2/utils/track_version.py
+++ b/pylearn2/utils/track_version.py
@@ -100,22 +100,20 @@ class LibVersion(object):
                     if v != 'unknown':
                         self.versions[repo] = v
                         continue
-                self.versions[repo] = self._get_git_version(self._get_module_parent_path(sys.modules[repo]))
+                self.versions[repo] = self._get_git_version(
+                    self._get_module_parent_path(sys.modules[repo]))
             except ImportError:
                 self.versions[repo] = None
 
         known = copy.copy(self.versions)
         # Put together all modules with unknown versions.
-        unknown = []
-        for k, v in known.items():
-            if v is None:
-                unknown.append(k)
-                del known[k]
+        unknown = [k for k, w in known.items() if not w]
+        known = dict((k, w) for k, w in known.items() if w)
 
         # Print versions.
-        self.str_versions = ' | '.join(['%s:%s' % (k, v)
-                               for k, v in sorted(six.iteritems(known))] +
-                               ['%s:?' % ','.join(sorted(unknown))])
+        self.str_versions = ' | '.join(
+            ['%s:%s' % (k, w) for k, w in sorted(six.iteritems(known))] +
+            ['%s:?' % ','.join(sorted(unknown))])
 
     def __str__(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     packages=find_packages(),
     description='A machine learning library built on top of Theano.',
     license='BSD 3-clause license',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', 'rb').read().decode('utf8'),
     dependency_links=['git+http://github.com/Theano/Theano.git#egg=Theano'],
     install_requires=['numpy>=1.5', 'pyyaml', 'argparse', "Theano"],
     package_data={


### PR DESCRIPTION
- correct .travis.yml
- make TransformerIterator iterable
- remove comparison "None > 0"
- use six.text_type instead of unicode
- use six.moves.input instead of raw_input
- use six.moves.reduce
- use operator module instead of lambda function
- integer conversion
- convert the pretrained test data
- remove some unused import
