### PR TITLE
Small typo ".ipnb" -> ".ipynb"

### DIFF
--- a/pylearn2/scripts/tutorials/README
+++ b/pylearn2/scripts/tutorials/README
@@ -7,7 +7,7 @@ and open the README.
 Some tutorials are ipython notebooks. These tutorials are single files with
 extension .ipynb. Run these tutorials using ipython, e.g.
 
-ipython notebook softmax_regression.ipnb
+ipython notebook softmax_regression.ipynb
 
 If you get an error message that looks like:
 WARNING:root:500 GET /notebooks/b4261b8b-9d9a-477c-b370-b57f6143ea27?_=1363474284017 (127.0.0.1): Unreadable JSON notebook.

--- a/pylearn2/scripts/tutorials/multilayer_perceptron/multilayer_perceptron.ipynb
+++ b/pylearn2/scripts/tutorials/multilayer_perceptron/multilayer_perceptron.ipynb
@@ -56571,7 +56571,7 @@
      "source": [
       "# Part 4: Regularization and pylearn2 costs\n",
       "\n",
-      "In softmax_regression.ipnb, we discussed the problem of overfitting, and how early stopping guided by validation set performance can result in better test set performance. Another way to prevent overfitting is to explicitly change the cost function to discourage overfitting.\n",
+      "In softmax_regression.ipynb, we discussed the problem of overfitting, and how early stopping guided by validation set performance can result in better test set performance. Another way to prevent overfitting is to explicitly change the cost function to discourage overfitting.\n",
       "\n",
       "The best way to prevent overfitting is to use Bayesian inference to predict labels on the new data. Suppose we have been given a dataset $\\mathcal{D}$, and we want to classify a new point $x'$. Call its uknown label $y'$. Suppose that we also have a probability distribution over all possible model parameters, and that we call the set of all parameters $\\theta$. Then\n",
       "\n",


### PR DESCRIPTION
Just a small typo in a README file.
