### PR TITLE
fix for quickstart on python3

### DIFF
--- a/pylearn2/datasets/cifar10.py
+++ b/pylearn2/datasets/cifar10.py
@@ -254,6 +254,6 @@ class CIFAR10(dense_design_matrix.DenseDesignMatrix):
 
         _logger.info('loading file %s' % fname)
         fo = open(fname, 'rb')
-        dict = cPickle.load(fo)
+        dict = cPickle.load(fo, encoding='latin-1')
         fo.close()
         return dict


### PR DESCRIPTION
To execute [Quick-start](http://deeplearning.net/software/pylearn2/tutorial/) on Python3, we need a little fix for loading cifar10 data.
The fix is same as Pull #1251 .
