### PR TITLE
Fixes to load STL10 dataset

### DIFF
--- a/pylearn2/datasets/stl10.py
+++ b/pylearn2/datasets/stl10.py
@@ -78,7 +78,7 @@ class STL10(dense_design_matrix.DenseDesignMatrix):
 
             if example_range is not None:
                 X = X[example_range[0]:example_range[1], :]
-            
+
             y_labels = 10
             # this is uint8 but labels range should be corrected
             y = train['y'][:, 0] - 1


### PR DESCRIPTION
The STL10 dataset cannot be loaded because an incorrect use of parameters: y and y_labels of DenseDesignMatrix. Sanity check at _check_labels at DenseDesignMatrix was failing.
