### PR TITLE
FiniteDatasetIterator gives more information when there are missing sources

### DIFF
--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -775,8 +775,15 @@ class FiniteDatasetIterator(object):
             sub_spaces = space.components
         assert len(source) == len(sub_spaces)
 
-        self._raw_data = tuple(all_data[dataset_source.index(s)]
-                               for s in source)
+        self._raw_data = ()
+        for s in source:
+            try:
+                self._raw_data += (all_data[dataset_source.index(s)],)
+            except ValueError as e:
+                msg = str(e) + '\nThe dataset does not provide '\
+                               'a source with name: '+s+'.'
+                reraise_as(ValueError(msg))
+
         self._source = source
         self._space = sub_spaces
 

--- a/pylearn2/utils/tests/test_iteration.py
+++ b/pylearn2/utils/tests/test_iteration.py
@@ -1,7 +1,11 @@
 """Tests for iterators."""
 from __future__ import print_function
 
+from nose.tools import assert_raises
 import numpy as np
+import theano
+from pylearn2.datasets.dense_design_matrix import DenseDesignMatrix
+from pylearn2.space import VectorSpace
 from pylearn2.utils.iteration import (
     SubsetIterator,
     SequentialSubsetIterator,
@@ -182,3 +186,22 @@ def test_uneven_batches():
     test_include_uneven_iterator(SequentialSubsetIterator)
     test_include_uneven_iterator(ShuffledSequentialSubsetIterator)
     test_include_uneven_iterator(BatchwiseShuffledSequentialIterator)
+    
+def test_finitedataset_source_check():
+    """
+    Check that the FiniteDatasetIterator returns sensible
+    errors when there is a missing source in the dataset.
+    """
+    dataset = DenseDesignMatrix(X=np.random.rand(20,15).astype(theano.config.floatX),
+                                y=np.random.rand(20,5).astype(theano.config.floatX))
+    assert_raises(ValueError,
+                  dataset.iterator,
+                  mode='sequential',
+                  batch_size=5,
+                  data_specs=(VectorSpace(15),'featuresX'))
+    try:
+        dataset.iterator(mode='sequential',
+                         batch_size=5,
+                         data_specs=(VectorSpace(15),'featuresX'))
+    except ValueError as e:
+        assert 'featuresX' in str(e)


### PR DESCRIPTION
Update for #1089. I added a better message when the dataset does not provide a source that was requested in the FiniteDatasetIterator.

Feedback is welcome.
