### PR TITLE
Fixed number_aware_alphabetical_cmp

### DIFF
--- a/pylearn2/utils/string_utils.py
+++ b/pylearn2/utils/string_utils.py
@@ -3,6 +3,7 @@
 import os
 import re
 
+from theano.compat.six import string_types
 from theano.compat.six.moves import xrange
 
 from pylearn2.utils.exc import EnvironmentVariableError, NoDataPathError
@@ -167,7 +168,11 @@ def number_aware_alphabetical_cmp(str1, str2):
     i = 0
 
     while i < l:
-        if seq1[i] < seq2[i]:
+        if isinstance(seq1[i], float) and isinstance(seq2[i], string_types):
+            return -1
+        elif isinstance(seq1[i], string_types) and isinstance(seq2[i], float):
+            return 1
+        elif seq1[i] < seq2[i]:
             return -1
         elif seq1[i] > seq2[i]:
             return 1

--- a/pylearn2/utils/tests/test_string_utils.py
+++ b/pylearn2/utils/tests/test_string_utils.py
@@ -161,10 +161,10 @@ def test_number_aware_alphabetical_key():
     on a specific example.
     """
 
-    l = ['mystr_1', 'mystr_10', 'mystr_2', 'mystr_1_a', 'mystr']
+    l = ['0', 'mystr_1', 'mystr_10', 'mystr_2', 'mystr_1_a', 'mystr']
 
     l.sort(key=number_aware_alphabetical_key)
 
     print(l)
 
-    assert l == ['mystr', 'mystr_1', 'mystr_1_a', 'mystr_2', 'mystr_10']
+    assert l == ['0', 'mystr', 'mystr_1', 'mystr_1_a', 'mystr_2', 'mystr_10']


### PR DESCRIPTION
In Python 3, comparison of `float` and `str` raises TypeError. In this commit, I added conditionals for checking types.