### PR TITLE
Introduce hash function for IndexSpace

### DIFF
--- a/pylearn2/space/__init__.py
+++ b/pylearn2/space/__init__.py
@@ -873,6 +873,9 @@ class IndexSpace(SimplyTypedSpace):
                                            max_labels=self.max_labels,
                                            dtype=self.dtype)
 
+    def __hash__(self):
+        return hash((type(self), self.dim, self.max_labels, self.dtype))
+
     def __eq__(self, other):
         """
         .. todo::


### PR DESCRIPTION
The absence of a hash function is causing errors in Python 3 (see https://travis-ci.org/bartvm/blocks/jobs/44774200)
