### PR TITLE
EpochMonitor callback for monitoring progress within epochs

### DIFF
--- a/pylearn2/devtools/tests/test_format.py
+++ b/pylearn2/devtools/tests/test_format.py
@@ -131,7 +131,6 @@ whitelist_pep8 = [
     "training_algorithms/tests/test_default.py",
     "training_algorithms/default.py",
     "training_algorithms/training_algorithm.py",
-    "training_algorithms/sgd.py",
     "distributions/tests/test_mnd.py",
     "distributions/parzen.py",
     "distributions/uniform_hypersphere.py",

--- a/pylearn2/training_algorithms/sgd.py
+++ b/pylearn2/training_algorithms/sgd.py
@@ -26,8 +26,8 @@ from pylearn2.space import CompositeSpace, NullSpace
 from pylearn2.train_extensions import TrainExtension
 from pylearn2.training_algorithms.training_algorithm import TrainingAlgorithm
 from pylearn2.training_algorithms.learning_rule import Momentum
-from pylearn2.training_algorithms.learning_rule import MomentumAdjustor \
-        as LRMomentumAdjustor
+from pylearn2.training_algorithms.learning_rule import (
+    MomentumAdjustor as LRMomentumAdjustor)
 from pylearn2.utils.iteration import is_stochastic, has_uniform_batch_size
 from pylearn2.utils import py_integer_types, py_float_types
 from pylearn2.utils import safe_zip
@@ -48,11 +48,11 @@ log = logging.getLogger(__name__)
 class SGD(TrainingAlgorithm):
     """
     SGD = (Minibatch) Stochastic Gradient Descent.
-    A TrainingAlgorithm that does stochastic gradient descent on minibatches
-    of training examples.
+    A TrainingAlgorithm that does stochastic gradient descent on
+    minibatches of training examples.
 
-    For theoretical background on this algorithm, see Yoshua Bengio's machine
-    learning course notes on the subject:
+    For theoretical background on this algorithm, see Yoshua Bengio's
+    machine learning course notes on the subject:
 
     http://www.iro.umontreal.ca/~pift6266/H10/notes/gradient.html
 
@@ -152,12 +152,12 @@ class SGD(TrainingAlgorithm):
     """
     def __init__(self, learning_rate, cost=None, batch_size=None,
                  monitoring_batch_size=None, monitoring_batches=None,
-                 monitoring_dataset=None, monitor_iteration_mode='sequential',
+                 monitoring_dataset=None,
+                 monitor_iteration_mode='sequential',
                  termination_criterion=None, update_callbacks=None,
-                 learning_rule = None,
-                 set_batch_size = False,
-                 train_iteration_mode = None, batches_per_iter=None,
-                 theano_function_mode = None, monitoring_costs=None,
+                 learning_rule=None, set_batch_size=False,
+                 train_iteration_mode=None, batches_per_iter=None,
+                 theano_function_mode=None, monitoring_costs=None,
                  seed=[2012, 10, 5]):
 
         if isinstance(cost, (list, tuple, set)):
@@ -189,7 +189,7 @@ class SGD(TrainingAlgorithm):
             train_iteration_mode = 'shuffled_sequential'
         self.train_iteration_mode = train_iteration_mode
         self.first = True
-        self.rng = make_np_rng(seed, which_method=["randn","randint"])
+        self.rng = make_np_rng(seed, which_method=["randn", "randint"])
         self.theano_function_mode = theano_function_mode
         self.monitoring_costs = monitoring_costs
 
@@ -216,7 +216,7 @@ class SGD(TrainingAlgorithm):
                                mode=self.monitor_iteration_mode)
             dataset_name = first_key(self.monitoring_dataset)
             monitoring_dataset = self.monitoring_dataset[dataset_name]
-            #TODO: have Monitor support non-data-dependent channels
+            # TODO: have Monitor support non-data-dependent channels
             self.monitor.add_channel(name='learning_rate',
                                      ipt=None,
                                      val=self.learning_rate,
@@ -225,8 +225,8 @@ class SGD(TrainingAlgorithm):
 
             if self.learning_rule:
                 self.learning_rule.add_channels_to_monitor(
-                        self.monitor,
-                        monitoring_dataset)
+                    self.monitor,
+                    monitoring_dataset)
 
     def setup(self, model, dataset):
         """
@@ -349,15 +349,16 @@ class SGD(TrainingAlgorithm):
 
         for key in lr_scalers:
             if key not in params:
-                raise ValueError("Tried to scale the learning rate on " +\
-                        str(key)+" which is not an optimization parameter.")
+                raise ValueError(
+                    "Tried to scale the learning rate on " +
+                    str(key) + " which is not an optimization parameter.")
 
         log.info('Parameter and initial learning rate summary:')
         for param in params:
             param_name = param.name
             if param_name is None:
                 param_name = 'anon_param'
-            lr = learning_rate.get_value() * lr_scalers.get(param,1.)
+            lr = learning_rate.get_value() * lr_scalers.get(param, 1.)
             log.info('\t' + param_name + ': ' + str(lr))
 
         if self.learning_rule:
@@ -365,9 +366,9 @@ class SGD(TrainingAlgorithm):
                 learning_rate, grads, lr_scalers))
         else:
             # Use standard SGD updates with fixed learning rate.
-            updates.update( dict(safe_zip(params, [param - learning_rate * \
-                lr_scalers.get(param, 1.) * grads[param]
-                                    for param in params])))
+            updates.update(dict(safe_zip(params, [param - learning_rate *
+                           lr_scalers.get(param, 1.) * grads[param]
+                           for param in params])))
 
         for param in params:
             if updates[param].name is None:
@@ -380,11 +381,10 @@ class SGD(TrainingAlgorithm):
             for update_val in get_debug_values(update):
                 if contains_inf(update_val):
                     raise ValueError("debug value of %s contains infs" %
-                            update.name)
+                                     update.name)
                 if contains_nan(update_val):
                     raise ValueError("debug value of %s contains nans" %
-                            update.name)
-
+                                     update.name)
 
         # Set up monitor to model the objective value, learning rate,
         # momentum (if applicable), and extra channels defined by
@@ -436,15 +436,17 @@ class SGD(TrainingAlgorithm):
             # No data will be returned by the iterator, and it is impossible
             # to know the size of the actual batch.
             # It is not decided yet what the right thing to do should be.
-            raise NotImplementedError("Unable to train with SGD, because "
-                    "the cost does not actually use data from the data set. "
-                    "data_specs: %s" % str(data_specs))
+            raise NotImplementedError(
+                "Unable to train with SGD, because "
+                "the cost does not actually use data from the data set. "
+                "data_specs: %s" % str(data_specs))
         flat_data_specs = (CompositeSpace(space_tuple), source_tuple)
 
         iterator = dataset.iterator(mode=self.train_iteration_mode,
-                batch_size=self.batch_size,
-                data_specs=flat_data_specs, return_tuple=True,
-                rng = rng, num_batches = self.batches_per_iter)
+                                    batch_size=self.batch_size,
+                                    data_specs=flat_data_specs,
+                                    return_tuple=True, rng=rng,
+                                    num_batches=self.batches_per_iter)
 
         on_load_batch = self.on_load_batch
         for batch in iterator:
@@ -481,6 +483,7 @@ class SGD(TrainingAlgorithm):
             return True
         else:
             return self.termination_criterion.continue_learning(self.model)
+
 
 class MonitorBasedLRAdjuster(TrainExtension):
     """
@@ -526,7 +529,7 @@ class MonitorBasedLRAdjuster(TrainExtension):
 
     def __init__(self, high_trigger=1., shrink_amt=.99,
                  low_trigger=.99, grow_amt=1.01,
-                 min_lr = 1e-7, max_lr = 1.,
+                 min_lr=1e-7, max_lr=1.,
                  dataset_name=None, channel_name=None):
         self.high_trigger = high_trigger
         self.shrink_amt = shrink_amt
@@ -558,32 +561,33 @@ class MonitorBasedLRAdjuster(TrainExtension):
         lr = algorithm.learning_rate
         current_learning_rate = lr.get_value()
         assert hasattr(model, 'monitor'), ("no monitor associated with "
-                + str(model))
+                                           + str(model))
         monitor = model.monitor
         monitor_channel_specified = True
 
         if self.channel_name is None:
             monitor_channel_specified = False
             channels = [elem for elem in monitor.channels
-                    if elem.endswith("objective")]
+                        if elem.endswith("objective")]
             if len(channels) < 1:
-                raise ValueError("There are no monitoring channels that end "
-                        "with \"objective\". Please specify either "
-                        "channel_name or dataset_name.")
+                raise ValueError(
+                    "There are no monitoring channels that end "
+                    "with \"objective\". Please specify either "
+                    "channel_name or dataset_name.")
             elif len(channels) > 1:
                 datasets = algorithm.monitoring_dataset.keys()
-                raise ValueError("There are multiple monitoring channels that"
-                        "end with \"_objective\". The list of available "
-                        "datasets are: " +
-                                str(datasets) + " . Please specify either "
-                                "channel_name or dataset_name in the "
-                                "MonitorBasedLRAdjuster constructor to "
-                                'disambiguate.')
+                raise ValueError(
+                    "There are multiple monitoring channels that"
+                    "end with \"_objective\". The list of available "
+                    "datasets are: " +
+                    str(datasets) + " . Please specify either "
+                    "channel_name or dataset_name in the "
+                    "MonitorBasedLRAdjuster constructor to "
+                    'disambiguate.')
             else:
                 self.channel_name = channels[0]
                 warnings.warn('The channel that has been chosen for '
-                        'monitoring is: ' +
-                              str(self.channel_name) + '.')
+                              'monitoring is: ' + str(self.channel_name) + '.')
 
         try:
             v = monitor.channels[self.channel_name].val_record
@@ -592,38 +596,41 @@ class MonitorBasedLRAdjuster(TrainExtension):
             if monitor_channel_specified:
                 if self.dataset_name:
                     err_input = 'The dataset_name \'' + str(
-                            self.dataset_name) + '\' is not valid.'
+                        self.dataset_name) + '\' is not valid.'
                 else:
                     err_input = 'The channel_name \'' + str(
-                            self.channel_name) + '\' is not valid.'
+                        self.channel_name) + '\' is not valid.'
             err_message = 'There is no monitoring channel named \'' + \
-                    str(self.channel_name) + '\'. You probably need to ' + \
-                    'specify a valid monitoring channel by using either ' + \
-                    'dataset_name or channel_name in the ' + \
-                    'MonitorBasedLRAdjuster constructor. ' + err_input
+                str(self.channel_name) + '\'. You probably need to ' + \
+                'specify a valid monitoring channel by using either ' + \
+                'dataset_name or channel_name in the ' + \
+                'MonitorBasedLRAdjuster constructor. ' + err_input
             reraise_as(ValueError(err_message))
 
         if len(v) < 1:
             if monitor.dataset is None:
                 assert len(v) == 0
-                raise ValueError("You're trying to use a monitor-based "
-                        "learning rate adjustor but the monitor has no "
-                        "entries because you didn't specify a "
-                        "monitoring dataset.")
+                raise ValueError(
+                    "You're trying to use a monitor-based "
+                    "learning rate adjustor but the monitor has no "
+                    "entries because you didn't specify a "
+                    "monitoring dataset.")
 
-            raise ValueError("For some reason there are no monitor entries"
-                                 "yet the MonitorBasedLRAdjuster has been "
-                                 "called. This should never happen. The Train"
-                                 " object should call the monitor once on "
-                                 "initialization, then call the callbacks. "
-                                 "It seems you are either calling the "
-                                 "callback manually rather than as part of a "
-                                 "training algorithm, or there is a problem "
-                                "with the Train object.")
+            raise ValueError(
+                "For some reason there are no monitor entries"
+                "yet the MonitorBasedLRAdjuster has been "
+                "called. This should never happen. The Train"
+                " object should call the monitor once on "
+                "initialization, then call the callbacks. "
+                "It seems you are either calling the "
+                "callback manually rather than as part of a "
+                "training algorithm, or there is a problem "
+                "with the Train object.")
+
         if len(v) == 1:
-            #only the initial monitoring has happened
-            #no learning has happened, so we can't adjust the learning rate yet
-            #just do nothing
+            # only the initial monitoring has happened
+            # no learning has happened, so we can't adjust learning rate yet
+            # just do nothing
             return
 
         rval = current_learning_rate
@@ -749,7 +756,8 @@ class AnnealedLearningRate(object):
             self._base = algorithm.learning_rate.get_value()
             self._initialized = True
         self._count += 1
-        algorithm.learning_rate.set_value(np.cast[config.floatX](self.current_learning_rate()))
+        algorithm.learning_rate.set_value(np.cast[config.floatX](
+            self.current_learning_rate()))
 
     def current_learning_rate(self):
         """
@@ -757,6 +765,7 @@ class AnnealedLearningRate(object):
         annealing schedule.
         """
         return self._base * min(1, self._anneal_start / self._count)
+
 
 class ExponentialDecay(object):
     """
@@ -813,6 +822,7 @@ class ExponentialDecay(object):
         new_lr = np.cast[config.floatX](new_lr)
         algorithm.learning_rate.set_value(new_lr)
 
+
 class LinearDecay(object):
     """
     This is a callback for the SGD algorithm rather than the Train object.
@@ -861,7 +871,7 @@ class LinearDecay(object):
         if self._count >= self.start:
             if self._count < self.saturate:
                 new_lr = self._base_lr - self._step * (self._count
-                        - self.start + 1)
+                                                       - self.start + 1)
             else:
                 new_lr = self._base_lr * self.decay_factor
         else:
@@ -869,6 +879,59 @@ class LinearDecay(object):
         assert new_lr > 0
         new_lr = np.cast[config.floatX](new_lr)
         algorithm.learning_rate.set_value(new_lr)
+
+
+class EpochMonitor(object):
+    """
+    This is a callback for the SGD algorithm rather than the Train object.
+    It can log one-line progress summaries and/or full monitor updates at
+    regular intervals within epochs, which can be useful for large datasets.
+
+    Note that each monitor update increases the calculation time of the epoch.
+
+    Parameters
+    ----------
+    model : pylearn2 model instance
+        The model being monitored
+    tick_rate : int (optional)
+        Log one-line updates every `tick_rate` batches
+    monitor_rate : int (optional)
+        Call full monitor updates within epochs every `monitor_rate` batches
+
+    YAML usage
+    ----------
+    model: &model !obj:pylearn2.models.mlp.MLP {
+        ...
+    },
+    algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        update_callbacks: [
+            !obj:pylearn2.training_algorithms.sgd.EpochMonitor {
+                model: *model,
+                tick_rate: 20,
+                monitor_rate: 110 }],
+        ...
+    }
+    """
+    def __init__(self, model, tick_rate=None, monitor_rate=None):
+        self.model = model
+        self.tick_rate = tick_rate
+        self.monitor_rate = monitor_rate
+        self.batches = 0
+        self.epoch = 1
+
+    def __call__(self, algorithm):
+        if self.model.monitor.get_epochs_seen() == self.epoch:
+            self.epoch += 1
+            self.batches = 0
+        else:
+            self.batches += 1
+            if self.monitor_rate and self.batches and not (
+                    self.batches % self.monitor_rate):
+                self.model.monitor.__call__()
+            elif self.tick_rate and not self.batches % self.tick_rate:
+                log.info('Epoch {}: {} batches seen'.format(
+                    self.epoch, self.batches))
+
 
 class OneOverEpoch(TrainExtension):
     """
@@ -885,7 +948,7 @@ class OneOverEpoch(TrainExtension):
     min_lr : float, optional
         The minimum value the learning rate can take on
     """
-    def __init__(self, start, half_life = None, min_lr = 1e-6):
+    def __init__(self, start, half_life=None, min_lr=1e-6):
         self.__dict__.update(locals())
         del self.self
         self._initialized = False
@@ -924,11 +987,12 @@ class OneOverEpoch(TrainExtension):
         if self._count < self.start:
             scale = 1
         else:
-            scale = float(self.half_life) / float(self._count - self.start
-                    + self.half_life)
+            scale = float(self.half_life) / float(self._count -
+                                                  self.start + self.half_life)
         lr = self._init_lr * scale
         clipped = max(self.min_lr, lr)
         return clipped
+
 
 class LinearDecayOverEpoch(TrainExtension):
     """
@@ -986,8 +1050,10 @@ class LinearDecayOverEpoch(TrainExtension):
         self._count += 1
         self._apply_learning_rate(algorithm)
 
-    def _apply_learning_rate(self, algorithm): 
-        """Updates the learning rate on algorithm based on the epochs elapsed."""
+    def _apply_learning_rate(self, algorithm):
+        """
+        Updates the learning rate on algorithm based on the epochs elapsed.
+        """
         if not self._initialized:
             self._init_lr = algorithm.learning_rate.get_value()
             self._step = ((self._init_lr - self._init_lr * self.decay_factor) /
@@ -1003,13 +1069,14 @@ class LinearDecayOverEpoch(TrainExtension):
         if self._count >= self.start:
             if self._count < self.saturate:
                 new_lr = self._init_lr - self._step * (self._count
-                        - self.start + 1)
+                                                       - self.start + 1)
             else:
                 new_lr = self._init_lr * self.decay_factor
         else:
             new_lr = self._init_lr
         assert new_lr > 0
         return new_lr
+
 
 class _PolyakWorker(object):
     """
@@ -1033,7 +1100,7 @@ class _PolyakWorker(object):
             self.param_to_mean[param] = mean
             avg_updates[mean] = mean - (mean - param) / t
             avg_updates[t] = t + 1.
-        self.avg = function([], updates = avg_updates)
+        self.avg = function([], updates=avg_updates)
 
     def __call__(self, algorithm):
         """
@@ -1045,6 +1112,7 @@ class _PolyakWorker(object):
         algorithm : WRITEME
         """
         self.avg()
+
 
 class PolyakAveraging(TrainExtension):
     """
@@ -1112,7 +1180,7 @@ class PolyakAveraging(TrainExtension):
         if self._count == self.start:
             self._worker = _PolyakWorker(model)
             algorithm.update_callbacks.append(self._worker)
-            #HACK
+            # HACK
             try:
                 model.add_polyak_channels(self._worker.param_to_mean,
                                           algorithm.monitoring_dataset)


### PR DESCRIPTION
When using a large training set, it can take a long time for the first epoch to complete and display the first monitor update. I wanted to see that progress was being made during the epoch, so I wrote an SGD callback to do this using the method suggested by Ian here https://groups.google.com/forum/#!topic/pylearn-users/Mz1_1yqSYeA

This can be used to print simple one-line updates giving the current epoch and batch at a specified rate, and/or to print monitor updates within epochs at a specified rate. 

I also made the file consistent with PEP8.