### PR TITLE
fix Reshape error and "Input dimension mis-match" when using Softmax layer with binary_target_dim > 1

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1432,7 +1432,8 @@ class Softmax(Layer):
             flat_Y.name = 'flat_Y'
             flat_log_prob = log_prob.flatten()
             flat_log_prob.name = 'flat_log_prob'
-            range_ = T.tile(T.arange(Y.shape[0]), (self.binary_target_dim,))
+            range_ = T.tile(T.arange(Y.shape[0]).dimshuffle(0,'x'), 
+                            (1,self.binary_target_dim)).flatten()
             flat_indices = flat_Y + range_ * self.n_classes
             flat_indices.name = 'flat_indices'
             log_prob_of = flat_log_prob[flat_indices].dimshuffle(0, 'x')

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1433,10 +1433,10 @@ class Softmax(Layer):
             flat_log_prob = log_prob.flatten()
             flat_log_prob.name = 'flat_log_prob'
             range_ = T.tile(T.arange(Y.shape[0]).dimshuffle(0,'x'), 
-                            (1,self.binary_target_dim)).flatten()
+                            (1, self.binary_target_dim)).flatten()
             flat_indices = flat_Y + range_ * self.n_classes
             flat_indices.name = 'flat_indices'
-            log_prob_of = flat_log_prob[flat_indices].dimshuffle(0, 'x')
+            log_prob_of = flat_log_prob[flat_indices].reshape(Y.shape, ndim=2)
             log_prob_of.name = 'log_prob_of'
 
         else:

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1137,7 +1137,9 @@ class Softmax(Layer):
         number of targets here so that an IndexSpace of the proper dimension
         can be used as the target space. This allows the softmax to compute
         the cost much more quickly than if it needs to convert the targets
-        into a VectorSpace.
+        into a VectorSpace. With binary_target_dim>1, you can use one layer
+        to simultaneously predict a bag of words (i.e. order is not important,
+        the same element can be included more than once).
     non_redundant : bool
         If True, learns only n_classes - 1 biases and weight vectors
     """

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1263,13 +1263,15 @@ class Softmax(Layer):
                                      ('max_max_class', mx.max()),
                                      ('min_max_class', mx.min())]))
 
-            if targets is not None:
-                y_hat = T.argmax(state, axis=1)
-                y = (targets.reshape(y_hat.shape) if self._has_binary_target
-                     else T.argmax(targets, axis=1))
-                misclass = T.neq(y, y_hat).mean()
-                misclass = T.cast(misclass, config.floatX)
-                rval['misclass'] = misclass
+            if (targets is not None):
+                if (not self._has_binary_target or self.binary_target_dim==1):
+                    # if binary_target_dim>1, the misclass rate is not well-defined
+                    y_hat = T.argmax(state, axis=1)
+                    y = (targets.reshape(y_hat.shape) if self._has_binary_target
+                         else T.argmax(targets, axis=1))
+                    misclass = T.neq(y, y_hat).mean()
+                    misclass = T.cast(misclass, config.floatX)
+                    rval['misclass'] = misclass
                 rval['nll'] = self.cost(Y_hat=state, Y=targets)
 
         return rval
@@ -1425,9 +1427,14 @@ class Softmax(Layer):
             # happen on the GPU rather than CPU.
 
             flat_Y = Y.flatten()
+            flat_Y.name = 'flat_Y'
             flat_log_prob = log_prob.flatten()
-            flat_indices = flat_Y + T.arange(Y.shape[0]) * self.n_classes
+            flat_log_prob.name = 'flat_log_prob'
+            flat_indices = flat_Y + T.tile(T.arange(Y.shape[0]), 
+                                           (self.binary_target_dim,)) * self.n_classes
+            flat_indices.name = 'flat_indices'
             log_prob_of = flat_log_prob[flat_indices].dimshuffle(0, 'x')
+            log_prob_of.name = 'log_prob_of'
 
         else:
             log_prob_of = (Y * log_prob)

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1436,7 +1436,7 @@ class Softmax(Layer):
             if self.binary_target_dim > 1:
                 # because of an error in optimization (local_useless_tile)
                 # when tiling with (1, 1)
-                range_ = T.tile(range_.dimshuffle(0,'x'), 
+                range_ = T.tile(range_.dimshuffle(0, 'x'),
                                 (1, self.binary_target_dim)).flatten()
             flat_indices = flat_Y + range_ * self.n_classes
             flat_indices.name = 'flat_indices'

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1264,10 +1264,11 @@ class Softmax(Layer):
                                      ('min_max_class', mx.min())]))
 
             if (targets is not None):
-                if (not self._has_binary_target or self.binary_target_dim == 1):
+                if ((not self._has_binary_target) or 
+                    self.binary_target_dim == 1):
                     # if binary_target_dim>1, the misclass rate is ill-defined
                     y_hat = T.argmax(state, axis=1)
-                    y = (targets.reshape(y_hat.shape) 
+                    y = (targets.reshape(y_hat.shape)
                          if self._has_binary_target
                          else T.argmax(targets, axis=1))
                     misclass = T.neq(y, y_hat).mean()

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1432,8 +1432,12 @@ class Softmax(Layer):
             flat_Y.name = 'flat_Y'
             flat_log_prob = log_prob.flatten()
             flat_log_prob.name = 'flat_log_prob'
-            range_ = T.tile(T.arange(Y.shape[0]).dimshuffle(0,'x'), 
-                            (1, self.binary_target_dim)).flatten()
+            range_ = T.arange(Y.shape[0])
+            if self.binary_target_dim > 1:
+                # because of an error in optimization (local_useless_tile)
+                # when tiling with (1, 1)
+                range_ = T.tile(range_.dimshuffle(0,'x'), 
+                                (1, self.binary_target_dim)).flatten()
             flat_indices = flat_Y + range_ * self.n_classes
             flat_indices.name = 'flat_indices'
             log_prob_of = flat_log_prob[flat_indices].reshape(Y.shape, ndim=2)

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1264,10 +1264,11 @@ class Softmax(Layer):
                                      ('min_max_class', mx.min())]))
 
             if (targets is not None):
-                if (not self._has_binary_target or self.binary_target_dim==1):
-                    # if binary_target_dim>1, the misclass rate is not well-defined
+                if (not self._has_binary_target or self.binary_target_dim == 1):
+                    # if binary_target_dim>1, the misclass rate is ill-defined
                     y_hat = T.argmax(state, axis=1)
-                    y = (targets.reshape(y_hat.shape) if self._has_binary_target
+                    y = (targets.reshape(y_hat.shape) 
+                         if self._has_binary_target
                          else T.argmax(targets, axis=1))
                     misclass = T.neq(y, y_hat).mean()
                     misclass = T.cast(misclass, config.floatX)
@@ -1430,8 +1431,8 @@ class Softmax(Layer):
             flat_Y.name = 'flat_Y'
             flat_log_prob = log_prob.flatten()
             flat_log_prob.name = 'flat_log_prob'
-            flat_indices = flat_Y + T.tile(T.arange(Y.shape[0]), 
-                                           (self.binary_target_dim,)) * self.n_classes
+            range_ = T.tile(T.arange(Y.shape[0]), (self.binary_target_dim,))
+            flat_indices = flat_Y + range_ * self.n_classes
             flat_indices.name = 'flat_indices'
             log_prob_of = flat_log_prob[flat_indices].dimshuffle(0, 'x')
             log_prob_of.name = 'log_prob_of'

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -1264,8 +1264,8 @@ class Softmax(Layer):
                                      ('min_max_class', mx.min())]))
 
             if (targets is not None):
-                if ((not self._has_binary_target) or 
-                    self.binary_target_dim == 1):
+                if ((not self._has_binary_target) or
+                        self.binary_target_dim == 1):
                     # if binary_target_dim>1, the misclass rate is ill-defined
                     y_hat = T.argmax(state, axis=1)
                     y = (targets.reshape(y_hat.shape)

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -625,7 +625,7 @@ def test_softmax_binary_targets():
 
 def test_softmax_two_binary_targets():
     """
-    Constructs softmax layers with binary target and with vector targets
+    Constructs softmax layers with two binary targets and with vector targets
     to check that they give the same cost.
     """
     num_classes = 10

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -651,7 +651,11 @@ def test_softmax_two_binary_targets():
                                allow_input_downcast=True)
 
     X_data = np.random.random(size=(batch_size, 100))
-    y_bin_data = np.random.randint(low=0, high=10, size=(batch_size, 2))
+    # binary and vector costs can only match 
+    # if binary targets are mutually exclusive
+    y_bin_data = np.concatenate([
+                             np.random.choice(10, size=(1, 2), replace=False)
+                             for _ in range(batch_size)])
     y_vec_data = np.zeros((batch_size, num_classes))
     y_vec_data[np.arange(batch_size),y_bin_data[:,0].flatten()] = 1
     y_vec_data[np.arange(batch_size),y_bin_data[:,1].flatten()] = 1

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -623,6 +623,41 @@ def test_softmax_binary_targets():
                                cost_vec(X_data, y_vec_data))
 
 
+def test_softmax_two_binary_targets():
+    """
+    Constructs softmax layers with binary target and with vector targets
+    to check that they give the same cost.
+    """
+    num_classes = 10
+    batch_size = 20
+    mlp_bin = MLP(
+        layers=[Softmax(num_classes, 's1', irange=0.1, binary_target_dim=2)],
+        nvis=100
+    )
+    mlp_vec = MLP(
+        layers=[Softmax(num_classes, 's1', irange=0.1)],
+        nvis=100
+    )
+
+    X = mlp_bin.get_input_space().make_theano_batch()
+    y_bin = mlp_bin.get_target_space().make_theano_batch()
+    y_vec = mlp_vec.get_target_space().make_theano_batch()
+
+    y_hat_bin = mlp_bin.fprop(X)
+    y_hat_vec = mlp_vec.fprop(X)
+    cost_bin = theano.function([X, y_bin], mlp_bin.cost(y_bin, y_hat_bin),
+                               allow_input_downcast=True)
+    cost_vec = theano.function([X, y_vec], mlp_vec.cost(y_vec, y_hat_vec),
+                               allow_input_downcast=True)
+
+    X_data = np.random.random(size=(batch_size, 100))
+    y_bin_data = np.random.randint(low=0, high=10, size=(batch_size, 2))
+    y_vec_data = np.zeros((batch_size, num_classes))
+    y_vec_data[np.arange(batch_size),y_bin_data[:,0].flatten()] = 1
+    y_vec_data[np.arange(batch_size),y_bin_data[:,1].flatten()] = 1
+    np.testing.assert_allclose(cost_bin(X_data, y_bin_data),
+                               cost_vec(X_data, y_vec_data))
+
 def test_softmax_weight_init():
     """
     Constructs softmax layers with different weight initialization

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -651,16 +651,16 @@ def test_softmax_two_binary_targets():
                                allow_input_downcast=True)
 
     X_data = np.random.random(size=(batch_size, 100))
-    # binary and vector costs can only match 
+    # binary and vector costs can only match
     # if binary targets are mutually exclusive
-    y_bin_data = np.concatenate([
-                             np.random.permutation(10)[:2].reshape((1,2))
-                             for _ in range(batch_size)])
+    y_bin_data = np.concatenate([np.random.permutation(10)[:2].reshape((1, 2))
+                                 for _ in range(batch_size)])
     y_vec_data = np.zeros((batch_size, num_classes))
-    y_vec_data[np.arange(batch_size),y_bin_data[:,0].flatten()] = 1
-    y_vec_data[np.arange(batch_size),y_bin_data[:,1].flatten()] = 1
+    y_vec_data[np.arange(batch_size), y_bin_data[:, 0].flatten()] = 1
+    y_vec_data[np.arange(batch_size), y_bin_data[:, 1].flatten()] = 1
     np.testing.assert_allclose(cost_bin(X_data, y_bin_data),
                                cost_vec(X_data, y_vec_data))
+
 
 def test_softmax_weight_init():
     """

--- a/pylearn2/models/tests/test_mlp.py
+++ b/pylearn2/models/tests/test_mlp.py
@@ -654,7 +654,7 @@ def test_softmax_two_binary_targets():
     # binary and vector costs can only match 
     # if binary targets are mutually exclusive
     y_bin_data = np.concatenate([
-                             np.random.choice(10, size=(1, 2), replace=False)
+                             np.random.permutation(10)[:2].reshape((1,2))
                              for _ in range(batch_size)])
     y_vec_data = np.zeros((batch_size, num_classes))
     y_vec_data[np.arange(batch_size),y_bin_data[:,0].flatten()] = 1


### PR DESCRIPTION
Using `binary_target_dim` rather than 1 will result in these errors:

````
ValueError: Input dimension mis-match. (input[0].shape[0] = 1968, input[2].shape[0] = 123)
Apply node that caused the error: Elemwise{Composite{[add(i0, mul(i1, i2))]}}[(0, 2)](Flatten{1}.0, TensorConstant{(1,) of 60000}, ARange.0)
Inputs types: [TensorType(int64, vector), TensorType(int64, (True,)), TensorType(int64, vector)]
Inputs shapes: [(1968,), (1,), (123,)]
Inputs strides: [(8,), (8,), (8,)]
Inputs scalar values: ['not scalar', array([60000]), 'not scalar']
````

and

````
ValueError: total size of new array must be unchanged
Apply node that caused the error: Reshape{1}(monitoring_targets, MakeVector.0)
Inputs types: [TensorType(int64, matrix), TensorType(int64, vector)]
Inputs shapes: [(10, 16), (1,)]
Inputs strides: [(136, 8), (8,)]
Inputs scalar values: ['not scalar', array([10])]
````

This commit fixes them.
