### PR TITLE
Hdf5 file handler fix and enhance

### DIFF
--- a/pylearn2/datasets/dense_design_matrix.py
+++ b/pylearn2/datasets/dense_design_matrix.py
@@ -1433,7 +1433,9 @@ class DefaultViewConverter(object):
                     "  self.shape:       %s (uses standard axis order: 0, 1, "
                     "'c')\n"
                     "  self.axes:        %s\n"
-                    "  topo_array.shape: %s (should be in self.axes' order)")
+                    "  topo_array.shape: %s (should be in self.axes' order)" %
+                    (axis, topo_array.shape[self.axes.index(axis)], shape_elem,
+                     self.shape, self.axes, topo_array.shape))
 
         topo_array_bc01 = topo_array.transpose([self.axes.index(ax)
                                                 for ax in ('b', 'c', 0, 1)])

--- a/pylearn2/datasets/hdf5.py
+++ b/pylearn2/datasets/hdf5.py
@@ -233,7 +233,12 @@ class HDF5DatasetIterator(FiniteDatasetIterator):
             try:
                 this_data = data[next_index]
             except TypeError:
-                this_data = data[next_index, :]
+                # Why this try..except is there? FB: I think this is useless.
+                # Do not hide the original if we can't fall back.
+                if data.ndim > 1:
+                    this_data = data[next_index, :]
+                else:
+                    raise
             if fn:
                 this_data = fn(this_data)
             assert not contains_nan(this_data)


### PR DESCRIPTION
__*** WORK IN PROGRESS ***__
This is my current refactor/remake of the hdf5.py file.

__There a few things missing/incomplete/wrong:__
- support to `tables` is partial at best. I added a few things for a test, but almost everything is still missing.
- ~~`use_h5py` should be set to True as default, since it was the default behaviour so far (and since tables is incomplete!)~~
- `HDF5VirtualTopoView.__getitem__`  should reshape the data in a "topological view format", according to the shape of the `item` input.
- The virtual objects should behave as numpy nd-arrays, therefore I guess we should check the methods exposed by a numpy array and try to replicate them or raise a NonImplementedError if too complicated to do.

__There are also many possible improvements:__
- get rid of the boolean mask in the iterator (i.e., rewrite the next method and delete the "else" part of `HDF5VirtualDesignMat.__getitem__`
- `design_mat2topo_view_idx`: the iteration over the cartesian product of indexes can be replaced with a single line of code with np.unravel_index. I played with it for a while, but I couldn't get it to work and left it as is for the moment.
- the `__getitem__` method in `HDF5VirtualTopoView` accesses the data on disk iterating over the `b`, `c` and `0` axes and reading chunks only on the `1` axis. This should be improved to read the biggest portion of sequential data as possible. The access to the disk (`self.design_matrix[b, base:base+offset:range_1[2]]`) is super slow right now. I don't know if there is something wrong in the `__getitem__`  method that reads the data or is just due to the fact that I am basically reading the images one line (column?) at the time. 
- It would be important to consider the case in which you convert the data twice (e.g. it is saved as a topological view on disk, you call `topo_view_to_design_mat` (getting an `HDF5VirtualDesignMat` object) and then call `design_mat_to_topo_view` on that object, going back to the original topological view). In this case you should avoid going through two transformation and simply return a HDF5Dataset object. This can be not so straightforward if you transposed the "virtual data", i.e., if you are accessing an object that has the same kind of view (dense design matrix or topological) as the data, but has a different shape.

Finally, I just noticed that I added to this branch a minor bugfix for `denseDesignMatrix.py`. It's late, so I am not rebasing it. :) If you prefer to move it in a separate PR, let me know and I will rebase.