### PR TITLE
Bugfixes in SVHN and DenseDesignMatrixPyTables

### DIFF
--- a/pylearn2/datasets/dense_design_matrix.py
+++ b/pylearn2/datasets/dense_design_matrix.py
@@ -1208,6 +1208,9 @@ class DenseDesignMatrixPyTables(DenseDesignMatrix):
             Either 'float' or 'int'. Decides the type of pytables atom
             used to store the y data. By default 'float' type is used.
         """
+        assert y_dtype in ['float', 'int'], (
+            "y_dtype can be 'float' or 'int' only"
+        )
 
         x_shape, y_shape = shapes
         # make pytables

--- a/pylearn2/datasets/dense_design_matrix.py
+++ b/pylearn2/datasets/dense_design_matrix.py
@@ -1081,9 +1081,9 @@ class DenseDesignMatrixPyTables(DenseDesignMatrix):
         length number examples. The remaining dimensions are xamples with
         topological significance, e.g. for images the remaining axes are rows,
         columns, and channels.
-    y : ndarray, 1-dimensional(?), optional
-        Labels or targets for each example. The semantics here are not quite
-        nailed down for this yet.
+    y : ndarray, optional
+        Labels or targets for each example. The semantics are similar to the
+        y argument used in DenseDesignMatrix.
     view_converter : object, optional
         An object for converting between design matrices and topological views.
         Currently DefaultViewConverter is the only type available but later we
@@ -1188,7 +1188,9 @@ class DenseDesignMatrixPyTables(DenseDesignMatrix):
                                             data_x=X,
                                             start=start)
 
-    def init_hdf5(self, path, shapes):
+    def init_hdf5(self, path, shapes,
+                  title="Pytables Dataset",
+                  y_dtype='float'):
         """
         Initializes the hdf5 file into which the data will be stored. This must
         be called before calling fill_hdf5.
@@ -1199,17 +1201,27 @@ class DenseDesignMatrixPyTables(DenseDesignMatrix):
             The name of the hdf5 file.
         shapes : tuple
             The shapes of X and y.
+        title : string, optional
+            Name of the dataset. e.g. For SVHN, set this to "SVHN Dataset".
+            "Pytables Dataset" is used as title, by default.
+        y_dtype : string, optional
+            Either 'float' or 'int'. Decides the type of pytables atom
+            used to store the y data. By default 'float' type is used.
         """
 
         x_shape, y_shape = shapes
         # make pytables
         ensure_tables()
-        h5file = tables.openFile(path, mode="w", title="SVHN Dataset")
+        h5file = tables.openFile(path, mode="w", title=title)
         gcolumns = h5file.createGroup(h5file.root, "Data", "Data")
         atom = (tables.Float32Atom() if config.floatX == 'float32'
                 else tables.Float64Atom())
         h5file.createCArray(gcolumns, 'X', atom=atom, shape=x_shape,
                             title="Data values", filters=self.filters)
+        if y_dtype != 'float':
+            # For 1D ndarray of int labels, override the atom to integer
+            atom = (tables.Int32Atom() if config.floatX == 'float32'
+                    else tables.Int64Atom())
         h5file.createCArray(gcolumns, 'y', atom=atom, shape=y_shape,
                             title="Data targets", filters=self.filters)
         return h5file, gcolumns
@@ -1294,6 +1306,10 @@ class DenseDesignMatrixPyTables(DenseDesignMatrix):
                                 shape=((stop - start, data.X.shape[1])),
                                 title="Data values",
                                 filters=self.filters)
+        if np.issubdtype(data.y, int):
+            # For 1D ndarray of int labels, override the atom to integer
+            atom = (tables.Int32Atom() if config.floatX == 'float32'
+                    else tables.Int64Atom())
         y = h5file.createCArray(gcolumns,
                                 'y',
                                 atom=atom,

--- a/pylearn2/datasets/svhn.py
+++ b/pylearn2/datasets/svhn.py
@@ -89,6 +89,8 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
         data = self.h5file.getNode('/', "Data")
 
         if start is not None or stop is not None:
+            if not hasattr(self, 'filters'):
+                self.filters = tables.Filters(complib='blosc', complevel=5)
             self.h5file, data = self.resize(self.h5file, start, stop)
 
         # rescale or center if permitted
@@ -134,15 +136,20 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
                  'train_all': 604388, 'valid': 6000, 'splitted_train': 598388}
         image_size = 32 * 32 * 3
         h_file_n = "{0}_32x32.h5".format(os.path.join(path, "h5", which_set))
+        # The table size for y is being set to [sizes[which_set], 1] since y
+        # contains the labels. If you are using the old one-hot scheme then this
+        # needs to be set to 10.
         h5file, node = self.init_hdf5(h_file_n,
                                       ([sizes[which_set], image_size],
-                                       [sizes[which_set], 10]))
+                                       [sizes[which_set], 1]),
+                                      title="SVHN Dataset",
+                                      y_dtype='int')
 
         # For consistency between experiments better to make new random stream
         rng = make_np_rng(None, 322, which_method="shuffle")
 
         def design_matrix_view(data_x):
-            """reshape data_x to deisng matrix view
+            """reshape data_x to design matrix view
             """
             data_x = numpy.transpose(data_x, axes=[3, 2, 0, 1])
             data_x = data_x.reshape((data_x.shape[0], 32 * 32 * 3))
@@ -235,8 +242,8 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
             train_x = numpy.cast[config.floatX](train_x)
             valid_x = numpy.cast[config.floatX](valid_x)
 
-            return design_matrix_view(train_x), train_y,\
-                design_matrix_view(valid_x), valid_y
+            return (design_matrix_view(train_x), train_y),\
+                (design_matrix_view(valid_x), valid_y)
 
         # The original splits
         if which_set in ['train', 'test']:
@@ -268,6 +275,11 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
 
         assert data_x.shape[0] == sizes[which_set]
         assert data_y.shape[0] == sizes[which_set]
+
+        # .mat labels for SVHN are in range [1,10]
+        # So subtract 1 to map labels to range [0,9]
+        # This is consistent with range for MNIST dataset labels
+        data_y = data_y - 1
 
         SVHN.fill_hdf5(h5file, data_x, data_y, node)
         h5file.close()

--- a/pylearn2/datasets/svhn.py
+++ b/pylearn2/datasets/svhn.py
@@ -46,7 +46,7 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
 
     def __init__(self, which_set, path=None, center=False, scale=False,
                  start=None, stop=None, axes=('b', 0, 1, 'c'),
-                 preprocessor = None):
+                 preprocessor=None):
 
         assert which_set in self.mapper.keys()
 
@@ -54,7 +54,7 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
         del self.self
 
         if path is None:
-            path = '${PYLEARN2_DATA_PATH}/SVHN/format2/'
+            path = self.data_path
             mode = 'r'
         else:
             mode = 'r+'
@@ -137,8 +137,8 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
         image_size = 32 * 32 * 3
         h_file_n = "{0}_32x32.h5".format(os.path.join(path, "h5", which_set))
         # The table size for y is being set to [sizes[which_set], 1] since y
-        # contains the labels. If you are using the old one-hot scheme then this
-        # needs to be set to 10.
+        # contains the labels. If you are using the old one-hot scheme then
+        # this needs to be set to 10.
         h5file, node = self.init_hdf5(h_file_n,
                                       ([sizes[which_set], image_size],
                                        [sizes[which_set], 1]),
@@ -180,7 +180,7 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
             """
 
             # load difficult train
-            data = load("{0}train_32x32.mat".format(SVHN.data_path))
+            data = load("{0}train_32x32.mat".format(path))
             valid_index = []
             for i in xrange(1, 11):
                 index = numpy.nonzero(data['y'] == i)[0]
@@ -207,7 +207,7 @@ class SVHN(dense_design_matrix.DenseDesignMatrixPyTables):
             gc.collect()
 
             # load extra train
-            data = load("{0}extra_32x32.mat".format(SVHN.data_path))
+            data = load("{0}extra_32x32.mat".format(path))
             valid_index = []
             for i in xrange(1, 11):
                 index = numpy.nonzero(data['y'] == i)[0]
@@ -307,7 +307,7 @@ class SVHN_On_Memory(dense_design_matrix.DenseDesignMatrix):
 
     def __init__(self, which_set, center=False, scale=False,
                  start=None, stop=None, axes=('b', 0, 1, 'c'),
-                 preprocessor = None):
+                 preprocessor=None):
 
         assert which_set in self.mapper.keys()
 

--- a/pylearn2/devtools/tests/test_format.py
+++ b/pylearn2/devtools/tests/test_format.py
@@ -556,6 +556,7 @@ whitelist_docstrings = [
     'scripts/datasets/make_cifar10_gcn_whitened.py',
     'scripts/datasets/make_cifar100_patches.py',
     'scripts/datasets/make_cifar100_gcn_whitened.py',
+    'scripts/datasets/make_svhn_pytables.py',
     'energy_functions/tests/test_rbm_energy.py',
 ]
 

--- a/pylearn2/scripts/datasets/make_svhn_pytables.py
+++ b/pylearn2/scripts/datasets/make_svhn_pytables.py
@@ -1,35 +1,34 @@
+"""
+Script to split the downloaded SVHN .mat files to 'test', 'valid', and 'train'
+sets and save them as pytables. Ensure that you have set the PYLEARN2_DATA_PATH
+environment variable and downloaded the .mat files to the path
+${PYLEARN2_DATA_PATH}/SVHN/format2/
+"""
 import os
-import logging
-import shutil
-from theano import config
-from pylearn2.datasets import preprocessing
 from pylearn2.datasets.svhn import SVHN
 from pylearn2.utils.string_utils import preprocess
 
-orig_path  = preprocess('${PYLEARN2_DATA_PATH}/SVHN/format2')
+orig_path = preprocess('${PYLEARN2_DATA_PATH}/SVHN/format2/')
 
 # Check if MAT files have been downloaded
 if not os.path.isdir(orig_path):
-    raise IOError("You need to download the SVNH format2 dataset MAT files "
-                     "before running this conversion script.")
+    raise IOError("You need to download the SVHN format2 dataset MAT files "
+                  "before running this conversion script.")
 
 # Create directory in which to save the pytables files
 local_path = orig_path
 if not os.path.isdir(os.path.join(local_path, 'h5')):
     os.makedirs(os.path.join(local_path, 'h5'))
 
-print """
-      ***************************************************************
-      Please ignore the warning produced during this MAT -> Pytables
-      conversion for the SVNH dataset. If you are creating the
-      pytables for the first time then no files are modified/over-written,
-      they are simply written for the first time.
-      ***************************************************************
-      """
+print("***************************************************************\n"
+      "Please ignore the warning produced during this MAT -> Pytables\n"
+      "conversion for the SVHN dataset. If you are creating the\n"
+      "pytables for the first time then no files are modified/over-written,\n"
+      "they are simply written for the first time.\n"
+      "***************************************************************\n")
 
-test = SVHN('test', path=local_path+'/')
+test = SVHN('test', path=local_path)
 
 valid = SVHN('valid', path=local_path)
 
 train = SVHN('splitted_train', path=local_path)
-

--- a/pylearn2/scripts/datasets/make_svhn_pytables.py
+++ b/pylearn2/scripts/datasets/make_svhn_pytables.py
@@ -7,6 +7,9 @@ ${PYLEARN2_DATA_PATH}/SVHN/format2/
 import os
 from pylearn2.datasets.svhn import SVHN
 from pylearn2.utils.string_utils import preprocess
+from pylearn2.testing.skip import skip_if_no_data
+
+skip_if_no_data() # Checking if PYLEARN2_DATA_PATH exists
 
 orig_path = preprocess('${PYLEARN2_DATA_PATH}/SVHN/format2/')
 

--- a/pylearn2/scripts/datasets/make_svhn_pytables.py
+++ b/pylearn2/scripts/datasets/make_svhn_pytables.py
@@ -1,0 +1,35 @@
+import os
+import logging
+import shutil
+from theano import config
+from pylearn2.datasets import preprocessing
+from pylearn2.datasets.svhn import SVHN
+from pylearn2.utils.string_utils import preprocess
+
+orig_path  = preprocess('${PYLEARN2_DATA_PATH}/SVHN/format2')
+
+# Check if MAT files have been downloaded
+if not os.path.isdir(orig_path):
+    raise IOError("You need to download the SVNH format2 dataset MAT files "
+                     "before running this conversion script.")
+
+# Create directory in which to save the pytables files
+local_path = orig_path
+if not os.path.isdir(os.path.join(local_path, 'h5')):
+    os.makedirs(os.path.join(local_path, 'h5'))
+
+print """
+      ***************************************************************
+      Please ignore the warning produced during this MAT -> Pytables
+      conversion for the SVNH dataset. If you are creating the
+      pytables for the first time then no files are modified/over-written,
+      they are simply written for the first time.
+      ***************************************************************
+      """
+
+test = SVHN('test', path=local_path+'/')
+
+valid = SVHN('valid', path=local_path)
+
+train = SVHN('splitted_train', path=local_path)
+

--- a/pylearn2/scripts/datasets/make_svhn_pytables.py
+++ b/pylearn2/scripts/datasets/make_svhn_pytables.py
@@ -7,9 +7,8 @@ ${PYLEARN2_DATA_PATH}/SVHN/format2/
 import os
 from pylearn2.datasets.svhn import SVHN
 from pylearn2.utils.string_utils import preprocess
-from pylearn2.testing.skip import skip_if_no_data
 
-skip_if_no_data() # Checking if PYLEARN2_DATA_PATH exists
+assert 'PYLEARN2_DATA_PATH' in os.environ, "PYLEARN2_DATA_PATH not defined"
 
 orig_path = preprocess('${PYLEARN2_DATA_PATH}/SVHN/format2/')
 


### PR DESCRIPTION

* [**fix**] split_train_valid method in SVHN class is expected to return two tuples, each with two values. But it was returning 4 values. This was
      wrongly introduced during commit af07b6cc076942ef4f80c84ec7c7148afb3999ad ("remove one_hot, first try...")
* [**fix**] Added support to specify y_labels in DenseDesignMatrixPyTables constructor.This should have been done as part of the following commits af07b6cc076942ef4f80c84ec7c7148afb3999ad ("remove one_hot, first try...") d6050106f137147ba976e472748ad77273218b55 ("Modified all super() params...")
* [**fix**] Table shape for y (the labels) is now set to [sizes[which_set], 1].
      Before it was being wrongly set to [sizes[which_set], 10]. Also y
      labels for SVHN now range from [0,9], similar to the MNIST dataset
      labels. These changes should have been done as part of commit
      af07b6cc076942ef4f80c84ec7c7148afb3999ad ("remove one_hot, first try...")
* [**fix**] Now the SVHN dataset class properly sets the filters attribute
      before call to resize().
* [**chg**] Removed hardcoded title specification in init_hdf5(). It can now
      be specified by an optional argument. SVHN class now sets the optional
      title argument.
* [**chg**] If dataset y is of integer type then int type atom is used by
      init_hdf5() for storing the labels in pytables.
* [**new**] Added ./pylearn2/scripts/datasets/download_svhn.sh script for SVHN
      dataset download to the $PYLEARN2_DATA_PATH/SVHN/format2 directory. The
      script is closely based on download_cifar10.sh, but it uses a verbose
      wget or curl.
* [**new**] Added ./pylearn2/scripts/datasets/make_svhn_pytables.py which
      converts the download MAT files for SVHN dataset to Pytables format.
* [**note**] The above fixes have been tested using SVHN YAML files in ./pylearn2/scripts/papers/maxout as follows:
       * [x] Setup your theano/pylearn2 to use GPU and set config.floatX = 'float32'
       * [x] Set the `PYLEARN2_DATA_PATH` environment variable.
       * [x] Download the SVHN dataset MAT files by running
           `./download_svhn.sh`
       * [x] Generate the necessary Pytables files by running
           `python make_svhn_pytables.py`
       * [x] Copy the generated dataset to an alternate path say /tmp/SVHN
       * [x] Set the `SVHN_LOCAL_PATH` environment variable to this path
          `export SVHN_LOCAL_PATH=/tmp/SVHN/`
       * [x] Pre-process the dataset by running
           `python svhn_preprocessing.py`
       * [x] Train on the processed dataset by running
           `THEANO_FLAGS="device=gpu,floatX=float32" python train.py svhn.yaml`
       * [x] For the first 10 iterations I got the following test_y_misclass
           1. test_y_misclass: 0.923491537571
           2. test_y_misclass: 0.804302871227
           3. test_y_misclass: 0.0927878990769
           4. test_y_misclass: 0.0584590695798
           5. test_y_misclass: 0.0481450334191
           6. test_y_misclass: 0.0444889366627
           7. test_y_misclass: 0.0405634306371
           8. test_y_misclass: 0.0373691543937
           9. test_y_misclass: 0.0350215472281
           10. test_y_misclass: 0.0334051698446