### PR TITLE
import serial in util/__init__.py for simpler importing

### DIFF
--- a/pylearn2/utils/__init__.py
+++ b/pylearn2/utils/__init__.py
@@ -27,6 +27,7 @@ WRAPPER_UPDATES = ('__dict__',)
 
 logger = logging.getLogger(__name__)
 
+from pylearn2.utils import serial
 
 def make_name(variable, anon="anonymous_variable"):
     """


### PR DESCRIPTION
Allows one to access pylearn2/utils/serial.py via "import pylearn2.utils.serial"