### PR TITLE
log_sum_exp tests and interface cleanup

### DIFF
--- a/pylearn2/expr/basic.py
+++ b/pylearn2/expr/basic.py
@@ -255,8 +255,12 @@ def log_sum_exp(A=None, axis=None, log_A=None):
     axis : int, optional
         Axis along which to sum
     log_A : deprecated
-        This function used to be specified in terms of log(A),
-        which was unnecessary and confusing. Just use A.
+        `A` used to be named `log_A`. We are removing the `log_A`
+        interface because there is no need for the input to be
+        the output of theano.tensor.log. The only change in the
+        renaming, i.e. the value of log_sum_exp(log_A=foo) has
+        not changed, and log_sum_exp(A=foo) is equivalent to
+        log_sum_exp(log_A=foo).
 
     Returns
     -------

--- a/pylearn2/expr/basic.py
+++ b/pylearn2/expr/basic.py
@@ -257,7 +257,7 @@ def log_sum_exp(A=None, axis=None, log_A=None):
     log_A : deprecated
         `A` used to be named `log_A`. We are removing the `log_A`
         interface because there is no need for the input to be
-        the output of theano.tensor.log. The only change in the
+        the output of theano.tensor.log. The only change is the
         renaming, i.e. the value of log_sum_exp(log_A=foo) has
         not changed, and log_sum_exp(A=foo) is equivalent to
         log_sum_exp(log_A=foo).

--- a/pylearn2/expr/basic.py
+++ b/pylearn2/expr/basic.py
@@ -242,23 +242,40 @@ def is_binary(x):
     return np.all( (x == 0) + (x == 1))
 
 
-def log_sum_exp(log_A, axis=None):
+def log_sum_exp(A=None, axis=None, log_A=None):
     """
     A numerically stable expression for
-    `T.log(T.exp(log_A).sum(axis=axis))`
+    `T.log(T.exp(A).sum(axis=axis))`
 
     Parameters
     ----------
-    log_A : tensor_like
-        Log of tensor A
+    A : theano.gof.Variable
+        A tensor we want to compute the log sum exp of
     axis : int, optional
         Axis along which to sum
+    log_A : deprecated
+        This function used to be specified in terms of log(A),
+        which was unnecessary and confusing. Just use A.
+
+    Returns
+    -------
+    log_sum_exp : theano.gof.Variable
+        The log sum exp of `A`
     """
-    log_A_max = T.max(log_A, axis=axis, keepdims=True)
+
+    if log_A is not None:
+        assert A is None
+        warnings.warn("log_A is deprecated, and will be removed on or"
+                      "after 2015-08-09. Switch to A")
+        A = log_A
+    del log_A
+
+    A_max = T.max(A, axis=axis, keepdims=True)
     B = (
-        T.log(T.sum(T.exp(log_A - log_A_max), axis=axis, keepdims=True)) +
-        log_A_max
+        T.log(T.sum(T.exp(A - A_max), axis=axis, keepdims=True)) +
+        A_max
     )
+
     if axis is None:
         return B.dimshuffle(())
     else:

--- a/pylearn2/expr/basic.py
+++ b/pylearn2/expr/basic.py
@@ -10,6 +10,7 @@ __email__ = "pylearn-dev@googlegroups"
 
 import numpy as np
 import theano.tensor as T
+import warnings
 
 from pylearn2.blocks import Block
 from pylearn2.utils import as_floatX, constantX

--- a/pylearn2/expr/tests/test_basic.py
+++ b/pylearn2/expr/tests/test_basic.py
@@ -1,0 +1,33 @@
+"""
+Tests for pylearn2.expr.basic
+"""
+
+import numpy as np
+
+from pylearn2.expr.basic import log_sum_exp
+from pylearn2.utils import sharedX
+
+
+def test_log_sum_exp_1():
+    """
+    Tests that the stable log sum exp matches the naive one for
+    values near 1.
+    """
+
+    rng = np.random.RandomState([2015, 2, 9])
+    x = 1. + rng.randn(5) / 10.
+    naive = np.log(np.exp(x).sum())
+    x = sharedX(x)
+    stable = log_sum_exp(x).eval()
+    assert np.allclose(naive, stable)
+
+
+def test_log_sum_exp_2():
+    """
+    Tests that the stable log sum exp succeeds for extreme values."
+    """
+
+    x = np.array([-100., 100.])
+    x = sharedX(x)
+    stable = log_sum_exp(x).eval()
+    assert np.allclose(stable, 100.)


### PR DESCRIPTION
log_sum_exp was unecessarily specified in terms of log A. This rephrases it to just be A, and adds some tests.