### PR TITLE
Handle TypeError in matplotlib import

### DIFF
--- a/pylearn2/utils/image.py
+++ b/pylearn2/utils/image.py
@@ -10,7 +10,7 @@ import warnings
 try:
     import matplotlib.pyplot as plt
     import matplotlib.axes
-except (RuntimeError, ImportError) as matplotlib_exception:
+except (RuntimeError, ImportError, TypeError) as matplotlib_exception:
     warnings.warn("Unable to import matplotlib. Some features unavailable. "
                   "Original exception: " + str(matplotlib_exception))
 import os


### PR DESCRIPTION
If pylearn2 is run in an environment without GUI (such as Ubuntu 14.04 Server), matplotlib import crashes. See https://github.com/lisa-lab/pylearn2/issues/1391