### PR TITLE
Fixed matplotlib import

### DIFF
--- a/pylearn2/packaged_dependencies/theano_linear/unshared_conv/localdot.py
+++ b/pylearn2/packaged_dependencies/theano_linear/unshared_conv/localdot.py
@@ -11,11 +11,13 @@ if cuda.cuda_available:
     import gpu_unshared_conv # register optimizations
 
 import numpy as np
+import warnings
 
 try:
     import matplotlib.pyplot as plt
-except ImportError:
-    pass
+except (RuntimeError, ImportError, TypeError) as matplotlib_exception:
+    warnings.warn("Unable to import matplotlib. Some features unavailable. "
+                  "Original exception: " + str(matplotlib_exception))
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Now matplotlib import here exactly mirrors that from https://github.com/lisa-lab/pylearn2/blob/master/pylearn2/utils/image.py, which is another fix for https://github.com/lisa-lab/pylearn2/issues/1391.