### PR TITLE
Support negative sampling

### DIFF
--- a/pylearn2/sandbox/nlp/models/mlp.py
+++ b/pylearn2/sandbox/nlp/models/mlp.py
@@ -1,18 +1,24 @@
 """
 Sandbox multilayer perceptron layers for natural language processing (NLP)
 """
-import theano.tensor as T
-from theano import config
-
+from pylearn2.compat import OrderedDict
 from pylearn2.models import mlp
 from pylearn2.models.mlp import Layer
+from pylearn2.sandbox.nlp.linear.matrixmul import MatrixMul
+from pylearn2.space import CompositeSpace
+from pylearn2.space import Space
 from pylearn2.space import IndexSpace
 from pylearn2.space import VectorSpace
-from pylearn2.space import CompositeSpace
 from pylearn2.utils import sharedX
 from pylearn2.utils import wraps
-from pylearn2.sandbox.nlp.linear.matrixmul import MatrixMul
-from pylearn2.compat import OrderedDict
+
+from pylearn2.expr.nnet import arg_of_sigmoid
+from pylearn2.space import Conv2DSpace
+from pylearn2.utils import py_integer_types
+from theano import tensor as T
+
+import numpy as np
+import theano
 
 
 class Softmax(mlp.Softmax):
@@ -105,12 +111,12 @@ class ProjectionLayer(Layer):
         row_norms = T.sqrt(sq_W.sum(axis=1))
         col_norms = T.sqrt(sq_W.sum(axis=0))
 
-        return OrderedDict([('row_norms_min',  row_norms.min()),
+        return OrderedDict([('row_norms_min', row_norms.min()),
                             ('row_norms_mean', row_norms.mean()),
-                            ('row_norms_max',  row_norms.max()),
-                            ('col_norms_min',  col_norms.min()),
+                            ('row_norms_max', row_norms.max()),
+                            ('col_norms_min', col_norms.min()),
                             ('col_norms_mean', col_norms.mean()),
-                            ('col_norms_max',  col_norms.max()), ])
+                            ('col_norms_max', col_norms.max()), ])
 
     def _check_input_space_and_get_max_labels(self, space):
         if isinstance(space, IndexSpace):
@@ -188,4 +194,278 @@ class ProjectionLayer(Layer):
             coeff = float(coeff)
         assert isinstance(coeff, float) or hasattr(coeff, 'dtype')
         W, = self.transformer.get_params()
+        return coeff * abs(W).sum()
+
+
+class ContrastiveProbabilityLayer(Layer):
+    """
+    Predicts the probability of a sample to come from a positive distribution
+    or a negative distribution. For each sample (i.e. a row in the input),
+    this layer produces *two* sets of probabilities. The first set has n
+    probabilities which says "if the sample is of class i then the probability
+    it comes from the positive distribution is p_i". The second set is the
+    complement of the first.
+
+    This layer should be provided with *two* targets, one positive and one
+    negative (randomly generated). To improve performance one should use
+    binary targets in which case the spaces should be index spaces.
+
+    It can be used to perform negative sampling.
+    """
+
+    def __init__(self, n_classes, layer_name, irange=None, sparse_init=None,
+                 istdev=None, binary_target_dim=None, no_affine=False):
+        super(ContrastiveProbabilityLayer, self).__init__()
+        self.__dict__.update(locals())
+        del self.self
+
+        if binary_target_dim is not None:
+            assert isinstance(binary_target_dim, py_integer_types)
+            self._has_binary_target = True
+            indiv_space = IndexSpace(dim=binary_target_dim,
+                                     max_labels=n_classes)
+        else:
+            self._has_binary_target = False
+            indiv_space = VectorSpace(n_classes)
+        self._target_space = CompositeSpace((indiv_space, indiv_space))
+        self.output_space = CompositeSpace((VectorSpace(n_classes),
+                                            VectorSpace(n_classes)))
+        if not no_affine:
+            self.b = sharedX(np.zeros((n_classes,)), name='contrast_b')
+
+    @wraps(Layer.set_input_space)
+    def set_input_space(self, space):
+
+        self.input_space = space
+
+        if not isinstance(space, Space):
+            raise TypeError("Expected Space, got " +
+                            str(space) + " of type " + str(type(space)))
+
+        self.input_dim = space.get_total_dimension()
+        self.needs_reformat = not isinstance(space, VectorSpace)
+
+        if self.no_affine:
+            desired_dim = self.n_classes
+            assert self.input_dim == desired_dim
+        else:
+            desired_dim = self.input_dim
+        self.desired_space = VectorSpace(desired_dim)
+
+        if not self.needs_reformat:
+            assert self.desired_space == self.input_space
+
+        rng = self.mlp.rng
+
+        if self.no_affine:
+            self._params = []
+        else:
+            num_cols = self.n_classes
+            if self.irange is not None:
+                assert self.istdev is None
+                assert self.sparse_init is None
+                W = rng.uniform(-self.irange,
+                                self.irange,
+                                (self.input_dim, num_cols))
+            elif self.istdev is not None:
+                assert self.sparse_init is None
+                W = rng.randn(self.input_dim, num_cols) * self.istdev
+            else:
+                assert self.sparse_init is not None
+                W = np.zeros((self.input_dim, num_cols))
+                for i in xrange(num_cols):
+                    for _ in xrange(self.sparse_init):
+                        idx = rng.randint(0, self.input_dim)
+                        while W[idx, i] != 0.:
+                            idx = rng.randint(0, self.input_dim)
+                        W[idx, i] = rng.randn()
+
+            self.W = sharedX(W, 'contrast_W')
+
+            self._params = [self.b, self.W]
+
+    @wraps(Layer.fprop)
+    def fprop(self, state_below):
+        self.input_space.validate(state_below)
+
+        if self.needs_reformat:
+            state_below = self.input_space.format_as(state_below,
+                                                     self.desired_space)
+
+        self.desired_space.validate(state_below)
+        assert state_below.ndim == 2
+
+        if not hasattr(self, 'no_affine'):
+            self.no_affine = False
+
+        if self.no_affine:
+            Z = state_below
+        else:
+            assert self.W.ndim == 2
+            Z = T.dot(state_below, self.W) + self.b
+
+        p = T.nnet.sigmoid(Z)
+        return (p, 1 - p)
+
+    def _open_affine_transformation(self, z):
+        assert not self.no_affine
+
+        assert hasattr(z, 'owner')
+        assert z.owner is not None
+        op = z.owner.op
+        assert isinstance(op, T.Elemwise)
+        assert isinstance(op.scalar_op, theano.scalar.basic.Add)
+        dot, b = z.owner.inputs
+
+        assert hasattr(dot, 'owner')
+        assert dot.owner is not None
+        assert isinstance(dot.owner.op, T.basic.Dot)
+        x, W = dot.owner.inputs
+
+        return x, W, b
+
+    def _cost(self, Y, Y_hat):
+
+        z = arg_of_sigmoid(Y_hat[0])
+        assert z.ndim == 2
+        nll_pos = T.nnet.softplus(-z)
+        nll_neg = T.nnet.softplus(-z) + z
+
+        if self._has_binary_target:
+
+            if self.no_affine:
+                # The following code is the equivalent of accessing log_prob
+                # by the indices in Y, but it is written such that the
+                # computation can happen on the GPU rather than CPU.
+                flat_Y_pos = Y[0].flatten()
+                flat_Y_neg = Y[1].flatten()
+                range_ = T.arange(Y[0].shape[0])
+                if self.binary_target_dim > 1:
+                    # because of an error in optimization (local_useless_tile)
+                    # when tiling with (1, 1)
+                    range_ = T.tile(range_.dimshuffle(0, 'x'),
+                                    (1, self.binary_target_dim)).flatten()
+                flat_indices_pos = flat_Y_pos + range_ * self.n_classes
+                flat_indices_neg = flat_Y_neg + range_ * self.n_classes
+                nll_pos = nll_pos.flatten()[flat_indices_pos] \
+                                .reshape(Y.shape, ndim=2)
+                nll_neg = nll_neg.flatten()[flat_indices_neg] \
+                                .reshape(Y.shape, ndim=2)
+                nll_of = (nll_pos, nll_neg)
+
+            else:
+                # Ignore the net input and activation, access the weights and
+                # biases corresponding to specified targets to get the best
+                # performance
+                x, W, b = self._open_affine_transformation(z)
+                flat_Y_pos = Y[0].flatten()
+                flat_Y_neg = Y[1].flatten()
+                batch_size = Y[0].shape[0]
+                W_pos = W[:, flat_Y_pos].reshape((batch_size, self.input_dim,
+                                                  self.binary_target_dim))
+                W_neg = W[:, flat_Y_neg].reshape((batch_size, self.input_dim,
+                                                  self.binary_target_dim))
+                b_pos = b[:, flat_Y_pos].reshape((batch_size,
+                                                  self.binary_target_dim))
+                b_neg = b[:, flat_Y_neg].reshape((batch_size,
+                                                  self.binary_target_dim))
+                z_pos = T.batched_dot(x, W_pos) + b_pos
+                z_neg = T.batched_dot(x, W_neg) + b_neg
+                nll_pos = T.nnet.softplus(-z_pos)
+                nll_neg = T.nnet.softplus(-z_neg) + z_neg
+                nll_of = (nll_pos, nll_neg)
+
+        else:
+            nll_of = (Y[0] * nll_pos, Y[1] * nll_neg)
+
+        return nll_of
+
+    @wraps(Layer.cost)
+    def cost(self, Y, Y_hat):
+
+        nll_pos, nll_neg = self._cost(Y, Y_hat)
+        nlls = (nll_pos + nll_neg).sum(axis=1)
+        assert nlls.ndim == 1
+
+        return nlls.mean()
+
+    @wraps(Layer.get_layer_monitoring_channels)
+    def get_layer_monitoring_channels(self, state_below=None,
+                                      state=None, targets=None):
+
+        rval = OrderedDict()
+
+        if (state_below is not None) or (state is not None):
+            if state is None:
+                state = self.fprop(state_below)
+
+            if (targets is not None):
+                if (self.binary_target_dim == 1):
+                    # if binary_target_dim>1, the misclass rate is ill-defined
+                    y_hat = T.argmax(state, axis=1)
+                    y = (targets.reshape(y_hat.shape)
+                         if self._has_binary_target
+                         else T.argmax(targets, axis=1))
+                    misclass = T.neq(y, y_hat).mean()
+                    misclass = T.cast(misclass, config.floatX)
+                    rval['misclass'] = misclass
+                rval['nll'] = self.cost(Y_hat=state, Y=targets)
+
+        return rval
+
+    @wraps(Layer.get_weights_topo)
+    def get_weights_topo(self):
+
+        if not isinstance(self.input_space, Conv2DSpace):
+            raise NotImplementedError()
+        desired = self.W.get_value().T
+        ipt = self.desired_space.np_format_as(desired, self.input_space)
+        rval = Conv2DSpace.convert_numpy(ipt,
+                                         self.input_space.axes,
+                                         ('b', 0, 1, 'c'))
+        return rval
+
+    @wraps(Layer.get_weights)
+    def get_weights(self):
+
+        if not isinstance(self.input_space, VectorSpace):
+            raise NotImplementedError()
+
+        return self.W.get_value()
+
+    @wraps(Layer.set_weights)
+    def set_weights(self, weights):
+
+        self.W.set_value(weights)
+
+    @wraps(Layer.set_biases)
+    def set_biases(self, biases):
+
+        self.b.set_value(biases)
+
+    @wraps(Layer.get_biases)
+    def get_biases(self):
+
+        return self.b.get_value()
+
+    @wraps(Layer.get_weights_format)
+    def get_weights_format(self):
+
+        return ('v', 'h')
+
+    @wraps(Layer.get_weight_decay)
+    def get_weight_decay(self, coeff):
+
+        if isinstance(coeff, str):
+            coeff = float(coeff)
+        assert isinstance(coeff, float) or hasattr(coeff, 'dtype')
+        return coeff * T.sqr(self.W).sum()
+
+    @wraps(Layer.get_l1_weight_decay)
+    def get_l1_weight_decay(self, coeff):
+
+        if isinstance(coeff, str):
+            coeff = float(coeff)
+        assert isinstance(coeff, float) or hasattr(coeff, 'dtype')
+        W = self.W
         return coeff * abs(W).sum()

--- a/pylearn2/sandbox/nlp/models/mlp.py
+++ b/pylearn2/sandbox/nlp/models/mlp.py
@@ -19,6 +19,7 @@ from pylearn2.utils import py_integer_types
 import theano
 from theano import tensor as T
 from theano import config
+from theano.compat.six.moves import xrange
 
 import numpy as np
 

--- a/pylearn2/sandbox/nlp/models/mlp.py
+++ b/pylearn2/sandbox/nlp/models/mlp.py
@@ -15,10 +15,12 @@ from pylearn2.utils import wraps
 from pylearn2.expr.nnet import arg_of_sigmoid
 from pylearn2.space import Conv2DSpace
 from pylearn2.utils import py_integer_types
+
+import theano
 from theano import tensor as T
+from theano import config
 
 import numpy as np
-import theano
 
 
 class Softmax(mlp.Softmax):

--- a/pylearn2/sandbox/nlp/models/mlp.py
+++ b/pylearn2/sandbox/nlp/models/mlp.py
@@ -235,7 +235,7 @@ class ContrastiveProbabilityLayer(Layer):
         can be used as the target space. This allows the layer to compute
         the cost much more quickly than if it needs to convert the targets
         into a VectorSpace. With binary_target_dim>1, you can use one layer
-        to simultaneously predict a bag of targets (i.e. order is not 
+        to simultaneously predict a bag of targets (i.e. order is not
         important, the same element can be included more than once).
     no_affine : boolean
         If True, sigmoid nonlinearity is applied directly to inputs.
@@ -375,10 +375,10 @@ class ContrastiveProbabilityLayer(Layer):
                                     (1, self.binary_target_dim)).flatten()
                 flat_indices_pos = flat_Y_pos + range_ * self.n_classes
                 flat_indices_neg = flat_Y_neg + range_ * self.n_classes
-                nll_pos = nll_pos.flatten()[flat_indices_pos] \
-                        .reshape(Y.shape, ndim=2)
-                nll_neg = nll_neg.flatten()[flat_indices_neg] \
-                        .reshape(Y.shape, ndim=2)
+                nll_pos = (nll_pos.flatten()[flat_indices_pos]
+                           .reshape(Y.shape, ndim=2))
+                nll_neg = (nll_neg.flatten()[flat_indices_neg]
+                           .reshape(Y.shape, ndim=2))
                 nll_of = (nll_pos, nll_neg)
 
             else:

--- a/pylearn2/sandbox/nlp/models/mlp.py
+++ b/pylearn2/sandbox/nlp/models/mlp.py
@@ -213,6 +213,32 @@ class ContrastiveProbabilityLayer(Layer):
     binary targets in which case the spaces should be index spaces.
 
     It can be used to perform negative sampling.
+
+    Parameters
+    ----------
+    n_classes : int
+        Number of classes.
+    layer_name : string
+        Name of the layer.
+    irange : float
+        If specified, initialized each weight randomly in
+        U(-irange, irange).
+    istdev : float
+        If specified, initialize each weight randomly from
+        N(0,istdev).
+    sparse_init : int
+        If specified, initial sparse_init number of weights
+        for each unit from N(0,1).
+    binary_target_dim : int, optional
+        If your targets are class labels (i.e. a binary vector) then set the
+        number of targets here so that an IndexSpace of the proper dimension
+        can be used as the target space. This allows the layer to compute
+        the cost much more quickly than if it needs to convert the targets
+        into a VectorSpace. With binary_target_dim>1, you can use one layer
+        to simultaneously predict a bag of targets (i.e. order is not 
+        important, the same element can be included more than once).
+    no_affine : boolean
+        If True, sigmoid nonlinearity is applied directly to inputs.
     """
 
     def __init__(self, n_classes, layer_name, irange=None, sparse_init=None,
@@ -350,9 +376,9 @@ class ContrastiveProbabilityLayer(Layer):
                 flat_indices_pos = flat_Y_pos + range_ * self.n_classes
                 flat_indices_neg = flat_Y_neg + range_ * self.n_classes
                 nll_pos = nll_pos.flatten()[flat_indices_pos] \
-                                .reshape(Y.shape, ndim=2)
+                        .reshape(Y.shape, ndim=2)
                 nll_neg = nll_neg.flatten()[flat_indices_neg] \
-                                .reshape(Y.shape, ndim=2)
+                        .reshape(Y.shape, ndim=2)
                 nll_of = (nll_pos, nll_neg)
 
             else:

--- a/pylearn2/sandbox/nlp/models/tests/negative-sampling.yaml
+++ b/pylearn2/sandbox/nlp/models/tests/negative-sampling.yaml
@@ -1,0 +1,64 @@
+!obj:pylearn2.train.Train {
+    dataset: &train !obj:pylearn2.datasets.vector_spaces_dataset.VectorSpacesDataset {
+        data: [
+                  !obj:numpy.random.randint { 
+                          'low': 0, 
+                          'high': &max_context_labels 10, 
+                          'size':[5, 16] 
+                        },
+                  !obj:numpy.random.randint { 
+                          'low': 0, 
+                          'high': &max_target_labels 12, 
+                          'size':[5, 1] 
+                        },
+                  !obj:numpy.random.randint { 
+                          'low': 0, 
+                          'high': *max_target_labels, 
+                          'size':[5, 1] 
+                        },
+              ],
+        data_specs: [
+                !obj:pylearn2.space.CompositeSpace { components: [
+                        &feature !obj:pylearn2.space.IndexSpace { 
+                            dim: 16,
+                            max_labels: *max_context_labels,
+                        },
+                        &target_pos !obj:pylearn2.space.IndexSpace {
+                            dim: 1,
+                            max_labels: *max_target_labels,
+                        },
+                        &target_neg !obj:pylearn2.space.IndexSpace {
+                            dim: 1,
+                            max_labels: *max_target_labels,
+                        },
+                    ] },
+                [ 'feature', 'target_pos', 'target_neg' ],
+              ]
+    },
+    model: !obj:pylearn2.models.mlp.MLP {
+        layers: [
+            !obj:pylearn2.sandbox.nlp.models.mlp.ProjectionLayer {
+                layer_name: 'projection',
+                dim: 4,
+                irange: 0.05,
+            }, !obj:pylearn2.sandbox.nlp.models.mlp.ContrastiveProbabilityLayer {
+                layer_name: 'contrast',
+                n_classes: *max_target_labels,
+                binary_target_dim: 1,
+                irange: 0.01,
+            },
+        ],
+        input_space: *feature,
+        input_source: 'feature',
+        target_source: ['target_pos', 'target_neg']
+    },
+    algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        train_iteration_mode: 'random_uniform',
+        batch_size: 5,
+        batches_per_iter: 1,
+        learning_rate: 0.01,
+        termination_criterion: !obj:pylearn2.termination_criteria.EpochCounter {
+            max_epochs: 10,
+        },
+    },
+}

--- a/pylearn2/sandbox/nlp/models/tests/test_mlp.py
+++ b/pylearn2/sandbox/nlp/models/tests/test_mlp.py
@@ -18,3 +18,11 @@ def test_projection_layer_yaml():
     with open(os.path.join(test_dir, 'composite.yaml')) as f:
         train = yaml_parse.load(f.read())
         train.main_loop()
+
+
+def test_contrastive_probability_layer_yaml():
+    """Test negative sampling."""
+    test_dir = os.path.dirname(__file__)
+    with open(os.path.join(test_dir, 'negative-sampling.yaml')) as f:
+        train = yaml_parse.load(f.read())
+        train.main_loop()


### PR DESCRIPTION
The main idea is one layer (with one set of weights and bias) produces two sets of complementary probabilities. One of them will be matched with positive examples, the other with negative random examples. I assume that one can generate those negative examples using a home-grown dataset or Pylearn2's transformer dataset. The default cost is negative log likelihood over both sets of probabilities.