### PR TITLE
OneHotFormatter: include dtype in symbolic expression

### DIFF
--- a/pylearn2/format/target_format.py
+++ b/pylearn2/format/target_format.py
@@ -201,7 +201,7 @@ class OneHotFormatter(object):
         else:
             if mode == 'concatenate':
                 one_hot = tensor.zeros((targets.shape[0] * targets.shape[1],
-                                        self._max_labels))
+                                        self._max_labels), dtype=self._dtype)
                 one_hot = tensor.set_subtensor(
                     one_hot[tensor.arange(targets.size),
                             targets.flatten()], 1)
@@ -209,13 +209,14 @@ class OneHotFormatter(object):
                     (targets.shape[0], targets.shape[1] * self._max_labels)
                 )
             elif mode == 'merge':
-                one_hot = tensor.zeros((targets.shape[0], self._max_labels))
+                one_hot = tensor.zeros((targets.shape[0], self._max_labels),
+                                       dtype=self._dtype)
                 one_hot = tensor.set_subtensor(
                     one_hot[tensor.arange(targets.size) % targets.shape[0],
                             targets.T.flatten()], 1)
             else:
                 one_hot = tensor.zeros((targets.shape[0], targets.shape[1],
-                                        self._max_labels))
+                                        self._max_labels), dtype=self._dtype)
                 one_hot = tensor.set_subtensor(one_hot[
                     tensor.arange(targets.shape[0]).reshape((targets.shape[0],
                                                              1)),

--- a/pylearn2/format/tests/test_target_format.py
+++ b/pylearn2/format/tests/test_target_format.py
@@ -12,6 +12,7 @@ def test_one_hot_formatter_simple():
         integer_labels = rng.random_integers(0, max_labels - 1, size=ncases)
         one_hot_labels = fmt.format(integer_labels)
         assert len(list(zip(*one_hot_labels.nonzero()))) == ncases
+        assert one_hot_labels.dtype == dtype
         for case, label in enumerate(integer_labels):
             assert one_hot_labels[case, label] == 1
     rng = numpy.random.RandomState(0)
@@ -32,6 +33,7 @@ def test_one_hot_formatter_symbolic():
         f = theano.function([x], y)
         one_hot_labels = f(integer_labels)
         assert len(list(zip(*one_hot_labels.nonzero()))) == ncases
+        assert one_hot_labels.dtype == dtype
         for case, label in enumerate(integer_labels):
             assert one_hot_labels[case, label] == 1
 


### PR DESCRIPTION
Simple fix: symbolic expressions for OneHotFormatter currently default to float32 (the formatter's dtype isn't passed on).

Thanks for the great library!