### PR TITLE
Adding even sequences subset iterator

### DIFF
--- a/pylearn2/tests/test_monitor.py
+++ b/pylearn2/tests/test_monitor.py
@@ -218,6 +218,8 @@ def test_revisit():
         
         for mode in sorted(_iteration_schemes):
             if mode == 'even_sequences' and nums is not None:
+                # even_sequences iterator does not support specifying a fixed number
+                # of minibatches.
                 continue
             for num_mon_batches in nums:
                 if num_mon_batches is None and mode in ['random_uniform', 'random_slice']:

--- a/pylearn2/tests/test_monitor.py
+++ b/pylearn2/tests/test_monitor.py
@@ -215,9 +215,11 @@ def test_revisit():
     for mon_batch_size in xrange(BATCH_SIZE, MAX_BATCH_SIZE + 1,
             BATCH_SIZE_STRIDE):
         nums = [1, 3, int(num_examples / mon_batch_size), None]
-        for num_mon_batches in nums:
-            for mode in sorted(_iteration_schemes):
-
+        
+        for mode in sorted(_iteration_schemes):
+            if mode == 'even_sequences' and nums is not None:
+                continue
+            for num_mon_batches in nums:
                 if num_mon_batches is None and mode in ['random_uniform', 'random_slice']:
                     continue
 

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1423,7 +1423,8 @@ def test_determinism():
         termination_criterion = EpochCounter(5)
 
         def run_algorithm():
-            unsupported_modes = ['random_slice', 'random_uniform', 'even_sequences']
+            unsupported_modes = ['random_slice', 'random_uniform',
+                                 'even_sequences']
             algorithm = SGD(learning_rate,
                             cost,
                             batch_size=batch_size,

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1423,7 +1423,7 @@ def test_determinism():
         termination_criterion = EpochCounter(5)
 
         def run_algorithm():
-            unsupported_modes = ['random_slice', 'random_uniform']
+            unsupported_modes = ['random_slice', 'random_uniform', 'even_sequences']
             algorithm = SGD(learning_rate,
                             cost,
                             batch_size=batch_size,

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1438,8 +1438,9 @@ def test_determinism():
             raised = False
             try:
                 algorithm.train(dataset)
-            except ValueError:
+            except ValueError as e:
                 print(mode)
+                print(e)
                 assert mode in unsupported_modes
                 raised = True
             if mode in unsupported_modes:

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1439,9 +1439,7 @@ def test_determinism():
             raised = False
             try:
                 algorithm.train(dataset)
-            except ValueError as e:
-                print(mode)
-                print(e)
+            except ValueError:
                 assert mode in unsupported_modes
                 raised = True
             if mode in unsupported_modes:

--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -678,7 +678,8 @@ class EvenSequencesSubsetIterator(SubsetIterator):
         elif isinstance(sequence_data, np.ndarray):
             self._dataset_size = sequence_data.shape[0]
         else:
-            raise ValueError("sequence_data must be of type list or np.ndarray")
+            raise ValueError("sequence_data must be of type list or"
+                             " ndarray")
         self._sequence_data = sequence_data
         self._batch_size = batch_size
         self.prepare()
@@ -689,7 +690,8 @@ class EvenSequencesSubsetIterator(SubsetIterator):
         self.lengths = [len(s) for s in self._sequence_data]
         self.len_unique = np.unique(self.lengths)
 
-        # store the indices of sequences for each unique length, and their counts
+        # store the indices of sequences for each unique length,
+        # and their counts
         self.len_indices = dict()
         self.len_counts = dict()
         for ll in self.len_unique:
@@ -727,13 +729,16 @@ class EvenSequencesSubsetIterator(SubsetIterator):
             curr_len = self.len_unique[self.len_idx]
             if self.len_curr_counts[curr_len] > 0:
                 break
-        
-        # find the position and the size of the minibatch of sequences to be returned
-        curr_batch_size = np.minimum(self._batch_size, self.len_curr_counts[curr_len])
+
+        # find the position and the size of the minibatch of sequences
+        # to be returned
+        curr_batch_size = np.minimum(self._batch_size,
+                                     self.len_curr_counts[curr_len])
         curr_pos = self.len_indices_pos[curr_len]
 
         # get the actual indices for the sequences
-        curr_indices = self.len_indices[curr_len][curr_pos:curr_pos+curr_batch_size]
+        curr_indices = self.len_indices[curr_len][curr_pos:curr_pos +
+                                                  curr_batch_size]
 
         # update the pointer and counts of sequences in the chosen length
         self.len_indices_pos[curr_len] += curr_batch_size

--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -645,7 +645,7 @@ class EvenSequencesSubsetIterator(SubsetIterator):
     An iterator for datasets with sequential data (e.g. list of words)
     which returns a list of indices of sequences in the dataset which have
     the same length.
-    Within one minibatch all sequences will have the same lenght, so it
+    Within one minibatch all sequences will have the same length, so it
     might return minibatches with different sizes depending on the
     distribution of the lengths of sequences in the data.
 

--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -655,9 +655,9 @@ class EvenSequencesSubsetIterator(SubsetIterator):
 
     Parameters
     ----------
-    sequence_data : list or ndarray
+    sequence_data : list of lists or ndarray of objects (ndarrays)
         The sequential data used to determine indices within the dataset such
-        that within a minibatch all sequences will have same lengths
+        that within a minibatch all sequences will have same lengths.
 
     See :py:class:`SubsetIterator` for detailed constructor parameter
     and attribute documentation.

--- a/pylearn2/utils/tests/test_iteration.py
+++ b/pylearn2/utils/tests/test_iteration.py
@@ -212,6 +212,10 @@ def test_finitedataset_source_check():
 
 
 def test_even_sequences():
+    """
+    Check that EvenSequencesSubsetIterator visits all entries
+    in a dataset of sequence data.
+    """
     rng = np.random.RandomState(123)
     lengths = rng.randint(1,10, 100)
     data = [['w']*l for l in lengths]
@@ -226,6 +230,10 @@ def test_even_sequences():
 
 
 def test_determinism_even_sequences():
+    """
+    Check that EvenSequencesSubsetIterator deterministically visits
+    entries of a dataset of sequence data.
+    """
     rng = np.random.RandomState(123)
     lengths = rng.randint(1,10, 100)
     data = [['w']*l for l in lengths]

--- a/pylearn2/utils/tests/test_iteration.py
+++ b/pylearn2/utils/tests/test_iteration.py
@@ -13,7 +13,8 @@ from pylearn2.utils.iteration import (
     RandomSliceSubsetIterator,
     RandomUniformSubsetIterator,
     BatchwiseShuffledSequentialIterator,
-    as_even
+    as_even,
+    EvenSequencesSubsetIterator,
 )
 
 
@@ -57,6 +58,7 @@ def test_correct_sequential_slices():
     assert sl.stop == 10
     assert sl.step is None
 
+    
 def test_correct_shuffled_sequential_slices():
 
     dataset_size = 13
@@ -141,6 +143,7 @@ def test_random_uniform():
         num += 1
     assert num == 10
 
+
 def test_batchwise_shuffled_sequential():
 
     iterator = BatchwiseShuffledSequentialIterator(30, batch_size = 7)
@@ -186,7 +189,8 @@ def test_uneven_batches():
     test_include_uneven_iterator(SequentialSubsetIterator)
     test_include_uneven_iterator(ShuffledSequentialSubsetIterator)
     test_include_uneven_iterator(BatchwiseShuffledSequentialIterator)
-    
+
+
 def test_finitedataset_source_check():
     """
     Check that the FiniteDatasetIterator returns sensible
@@ -205,3 +209,17 @@ def test_finitedataset_source_check():
                          data_specs=(VectorSpace(15),'featuresX'))
     except ValueError as e:
         assert 'featuresX' in str(e)
+
+
+def test_even_sequences():
+    np.random.seed(123)
+    lengths = np.random.randint(1,10, 100)
+    data = [['w']*l for l in lengths]
+    batch_size = 5
+    my_iter = EvenSequencesSubsetIterator(data, batch_size)
+    visited = [False] * len(data)
+    for ind_list in my_iter:
+        assert [len(data[i]) == len(data[ind_list[0]]) for i in ind_list]
+        for i in ind_list:
+            visited[i] = True
+    assert all(visited)

--- a/pylearn2/utils/tests/test_iteration.py
+++ b/pylearn2/utils/tests/test_iteration.py
@@ -212,8 +212,8 @@ def test_finitedataset_source_check():
 
 
 def test_even_sequences():
-    np.random.seed(123)
-    lengths = np.random.randint(1,10, 100)
+    rng = np.random.RandomState(123)
+    lengths = rng.randint(1,10, 100)
     data = [['w']*l for l in lengths]
     batch_size = 5
     my_iter = EvenSequencesSubsetIterator(data, batch_size)
@@ -223,3 +223,24 @@ def test_even_sequences():
         for i in ind_list:
             visited[i] = True
     assert all(visited)
+
+
+def test_determinism_even_sequences():
+    rng = np.random.RandomState(123)
+    lengths = rng.randint(1,10, 100)
+    data = [['w']*l for l in lengths]
+    batch_size = 5
+    my_iter = EvenSequencesSubsetIterator(data, batch_size)
+    visited1 = [0] * len(data)
+    for b_ind, ind_list in enumerate(my_iter):
+        assert [len(data[i]) == len(data[ind_list[0]]) for i in ind_list]
+        for i in ind_list:
+            visited1[i] = b_ind
+
+    my_iter = EvenSequencesSubsetIterator(data, batch_size)
+    visited2 = [0] * len(data)
+    for b_ind, ind_list in enumerate(my_iter):
+        assert [len(data[i]) == len(data[ind_list[0]]) for i in ind_list]
+        for i in ind_list:
+            visited2[i] = b_ind
+    assert np.all(np.asarray(visited1) == np.asarray(visited2))


### PR DESCRIPTION
This iterator is used for datasets with sequential data (e.g. list of words). It returns a list of indices such that sequences within a minibatch which will have the same lengths.
Therefore, it might return minibatches with different sizes, but it usually gives a speedup of 20% for processing sequential data.