### PR TITLE
ConvElemwise now sets tied_b to the correct default

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -2969,6 +2969,9 @@ class ConvElemwise(Layer):
 
         assert nonlinearity is not None
 
+        if tied_b is None:
+            self.tied_b = True
+
         self.nonlin = nonlinearity
         self.__dict__.update(locals())
         assert monitor_style in ['classification', 'detection'], (


### PR DESCRIPTION
This commit should fix #1430. One thing I noticed is that the default is overwritten in ConvRectifiedLinear, should this not be True there also?