### PR TITLE
fix SequenceDatasetIterator's small bug

### DIFF
--- a/pylearn2/sandbox/rnn/utils/iteration.py
+++ b/pylearn2/sandbox/rnn/utils/iteration.py
@@ -126,7 +126,7 @@ class SequenceDatasetIterator(FiniteDatasetIterator):
                 # Create mask
                 if source in self.mask_needed:
                     mask = self._create_mask(rval)
-                rval = np.transpose(batch, (1, 0, 2))
+                rval = np.swapaxes(batch, 0, 1)
                 if fn:
                     rval = fn(rval)
                 rvals.append(rval)


### PR DESCRIPTION
`batch` might have a shape like (batch_size, sequence_length, feature, feature, ...).
The original code uses `np.transpose(batch, (1, 0, 2))` to swap the 0th and the 1st axes.
But using `np.swapaxis(batch, 0, 1)` is better than `np.transpose`.

Currently this is not a problem since the possible dimension of `batch` is only 3.
But in the future, if one want to use the space `SequenceDataSpace(Conv2DSpace)` (currently this is not allowed to use with RNN), the shape of `batch` will be (batch_size, sequence_length, row, col, channel) which dimension is 5 and `np.transpose(batch, (1, 0, 2))` will not match its shape.