### PR TITLE
fix incorrect parameter name in docstrings of LSTM and GRU

### DIFF
--- a/pylearn2/sandbox/rnn/models/rnn.py
+++ b/pylearn2/sandbox/rnn/models/rnn.py
@@ -422,12 +422,13 @@ class LSTM(Recurrent):
         The name of the layer. All layers in an MLP must have a unique name.
     irange : float
         Initializes each weight randomly in U(-irange, irange)
-    output : slice, list of integers or integer, optional
+    indices : slice, list of integers or integer, optional
         If specified this layer will return only the given hidden
         states. If an integer is given, it will not return a
         SequenceSpace. Otherwise, it will return a SequenceSpace of
         fixed length. Note that a SequenceSpace of fixed length
         can be flattened by using the FlattenerLayer.
+        Note: For now only [-1] is supported.
     irange : float
     init_bias : float
     forget_gate_init_bias : float
@@ -617,12 +618,13 @@ class GRU(Recurrent):
         The name of the layer. All layers in an MLP must have a unique name.
     irange : float
         Initializes each weight randomly in U(-irange, irange)
-    output : slice, list of integers or integer, optional
+    indices : slice, list of integers or integer, optional
         If specified this layer will return only the given hidden
         states. If an integer is given, it will not return a
         SequenceSpace. Otherwise, it will return a SequenceSpace of
         fixed length. Note that a SequenceSpace of fixed length
         can be flattened by using the FlattenerLayer.
+        Note: For now only [-1] is supported.
     irange : float
     init_bias : float
     reset_gate_init_bias: float


### PR DESCRIPTION
The docstrings of `LSTM` and `GRU` about `output` parameter are incorrect. 
Actual parameter name that they expect is `indices` as `Recurrent`.

The docstring of `Recurrent` class has been correctly fixed at [this commit](https://github.com/lisa-lab/pylearn2/commit/df3a0c54af23431042c30063de4615b916cf6c89#diff-99dd2c7f58dcebb88cf63a031a0a017aR37). 
But at that time the `LSTM`'s docstring was left incorrect.
After that, the `GRU`'s docstring is copied from `LSTM`'s one at [this commit](https://github.com/lisa-lab/pylearn2/commit/62bc2cc3689196cbe38346bf389188a604f8b44e#diff-99dd2c7f58dcebb88cf63a031a0a017aR620).