### PR TITLE
Add corruptor in DeepComposedAutoencoder, fix #1356

### DIFF
--- a/pylearn2/models/autoencoder.py
+++ b/pylearn2/models/autoencoder.py
@@ -716,7 +716,7 @@ class DeepComposedAutoencoder(AbstractAutoencoder):
     autoencoders : list
         A list of autoencoder objects.
     """
-    def __init__(self, autoencoders):
+    def __init__(self, autoencoders, corruptor=None):
         super(DeepComposedAutoencoder, self).__init__()
         self.fn = None
         self.cpu_only = False
@@ -727,6 +727,21 @@ class DeepComposedAutoencoder(AbstractAutoencoder):
         self.autoencoders = list(autoencoders)
         self.input_space = autoencoders[0].get_input_space()
         self.output_space = autoencoders[-1].get_output_space()
+        self.corruptor = corruptor
+
+    @functools.wraps(Autoencoder.reconstruct)
+    def reconstruct(self, inputs):
+        """
+        .. todo::
+
+            WRITEME
+        """
+        corrupted = None
+        if self.corruptor is None:
+            corrupted = inputs
+        else:
+            corrupted = self.corruptor(inputs)
+        return self.decode(self.encode(corrupted))
 
     @functools.wraps(Autoencoder.encode)
     def encode(self, inputs):

--- a/pylearn2/models/tests/test_autoencoder.py
+++ b/pylearn2/models/tests/test_autoencoder.py
@@ -9,7 +9,7 @@ import theano.tensor as tensor
 from theano import config
 from pylearn2.models.autoencoder import Autoencoder, \
     HigherOrderContractiveAutoencoder, DeepComposedAutoencoder, \
-    UntiedAutoencoder
+    UntiedAutoencoder, StackedDenoisingAutoencoder
 from pylearn2.corruption import BinomialCorruptor
 from pylearn2.config import yaml_parse
 from theano.tensor.basic import _allclose
@@ -123,15 +123,15 @@ def test_dcae():
     model.perform(data)
 
 
-def test_denoising_dcae():
+def test_sdae():
     """
-    Tests that Denoising DeepComposedAutoencoder works correctly
+    Tests that StackedDenoisingAutoencoder works correctly
     """
     data = np.random.randn(10, 5).astype(config.floatX) * 100
     ae = Autoencoder(5, 7, act_enc='tanh', act_dec='cos',
                      tied_weights=False)
     corruptor = BinomialCorruptor(corruption_level=0.5)
-    model = DeepComposedAutoencoder([ae], corruptor=corruptor)
+    model = StackedDenoisingAutoencoder([ae], corruptor)
     model._ensure_extensions()
 
     w = ae.weights.get_value()

--- a/pylearn2/models/tests/test_autoencoder.py
+++ b/pylearn2/models/tests/test_autoencoder.py
@@ -130,8 +130,8 @@ def test_denoising_dcae():
     data = np.random.randn(10, 5).astype(config.floatX) * 100
     ae = Autoencoder(5, 7, act_enc='tanh', act_dec='cos',
                      tied_weights=False)
-    model = DeepComposedAutoencoder([ae],
-        corruptor=BinomialCorruptor(corruption_level=0.5))
+    corruptor = BinomialCorruptor(corruption_level=0.5)
+    model = DeepComposedAutoencoder([ae], corruptor=corruptor)
     model._ensure_extensions()
 
     w = ae.weights.get_value()

--- a/pylearn2/models/tests/test_autoencoder.py
+++ b/pylearn2/models/tests/test_autoencoder.py
@@ -122,6 +122,7 @@ def test_dcae():
     data = np.random.randn(10, 5).astype(config.floatX)
     model.perform(data)
 
+
 def test_denoising_dcae():
     """
     Tests that Denoising DeepComposedAutoencoder works correctly
@@ -129,7 +130,8 @@ def test_denoising_dcae():
     data = np.random.randn(10, 5).astype(config.floatX) * 100
     ae = Autoencoder(5, 7, act_enc='tanh', act_dec='cos',
                      tied_weights=False)
-    model = DeepComposedAutoencoder([ae], corruptor=BinomialCorruptor(corruption_level=0.5))
+    model = DeepComposedAutoencoder([ae],
+        corruptor=BinomialCorruptor(corruption_level=0.5))
     model._ensure_extensions()
 
     w = ae.weights.get_value()

--- a/pylearn2/models/tests/test_autoencoder.py
+++ b/pylearn2/models/tests/test_autoencoder.py
@@ -121,3 +121,24 @@ def test_dcae():
 
     data = np.random.randn(10, 5).astype(config.floatX)
     model.perform(data)
+
+def test_denoising_dcae():
+    """
+    Tests that Denoising DeepComposedAutoencoder works correctly
+    """
+    data = np.random.randn(10, 5).astype(config.floatX) * 100
+    ae = Autoencoder(5, 7, act_enc='tanh', act_dec='cos',
+                     tied_weights=False)
+    model = DeepComposedAutoencoder([ae], corruptor=BinomialCorruptor(corruption_level=0.5))
+    model._ensure_extensions()
+
+    w = ae.weights.get_value()
+    w_prime = ae.w_prime.get_value()
+    ae.hidbias.set_value(np.random.randn(7).astype(config.floatX))
+    hb = ae.hidbias.get_value()
+    ae.visbias.set_value(np.random.randn(5).astype(config.floatX))
+    vb = ae.visbias.get_value()
+    d = tensor.matrix()
+    result = np.cos(np.dot(np.tanh(hb + np.dot(data,  w)), w_prime) + vb)
+    ff = theano.function([d], model.reconstruct(d))
+    assert not _allclose(ff(data), result)

--- a/pylearn2/monitor.py
+++ b/pylearn2/monitor.py
@@ -438,8 +438,7 @@ class Monitor(object):
             it.append(d.iterator(mode=i, num_batches=n, batch_size=b,
                                  data_specs=self._flat_data_specs,
                                  return_tuple=True))
-        self.num_examples = [np.cast[config.floatX](float(i.num_examples))
-                             for i in it]
+        self.num_examples = [i.num_examples for i in it]
         givens = [OrderedDict() for d in self._datasets]
         updates = [OrderedDict() for d in self._datasets]
         for i, channel in enumerate(self.channels.values()):
@@ -474,8 +473,7 @@ class Monitor(object):
                 if n == 0:
                     raise ValueError("Iterating over 0 examples results in " +
                                      "divide by 0")
-                val = (channel.val * T.cast(batch_size, config.floatX)
-                       / cur_num_examples)
+                val = T.cast(channel.val * batch_size / cur_num_examples, config.floatX)
             u[channel.val_shared] = channel.val_shared + val
 
         with log_timing(log, "Compiling accum"):

--- a/pylearn2/monitor.py
+++ b/pylearn2/monitor.py
@@ -473,7 +473,8 @@ class Monitor(object):
                 if n == 0:
                     raise ValueError("Iterating over 0 examples results in " +
                                      "divide by 0")
-                val = T.cast(channel.val * batch_size / cur_num_examples, config.floatX)
+                val = T.cast(channel.val * batch_size / cur_num_examples,
+                             config.floatX)
             u[channel.val_shared] = channel.val_shared + val
 
         with log_timing(log, "Compiling accum"):

--- a/pylearn2/monitor.py
+++ b/pylearn2/monitor.py
@@ -438,7 +438,8 @@ class Monitor(object):
             it.append(d.iterator(mode=i, num_batches=n, batch_size=b,
                                  data_specs=self._flat_data_specs,
                                  return_tuple=True))
-        self.num_examples = [i.num_examples for i in it]
+        self.num_examples = [np.cast['float64'](float(i.num_examples))
+                             for i in it]
         givens = [OrderedDict() for d in self._datasets]
         updates = [OrderedDict() for d in self._datasets]
         for i, channel in enumerate(self.channels.values()):
@@ -473,8 +474,8 @@ class Monitor(object):
                 if n == 0:
                     raise ValueError("Iterating over 0 examples results in " +
                                      "divide by 0")
-                val = T.cast(channel.val * batch_size / cur_num_examples,
-                             config.floatX)
+                val = T.cast(channel.val * T.cast(batch_size, 'float64')
+                             / cur_num_examples, config.floatX)
             u[channel.val_shared] = channel.val_shared + val
 
         with log_timing(log, "Compiling accum"):

--- a/pylearn2/monitor.py
+++ b/pylearn2/monitor.py
@@ -438,8 +438,7 @@ class Monitor(object):
             it.append(d.iterator(mode=i, num_batches=n, batch_size=b,
                                  data_specs=self._flat_data_specs,
                                  return_tuple=True))
-        self.num_examples = [np.cast['float64'](float(i.num_examples))
-                             for i in it]
+        self.num_examples = [i.num_examples for i in it]
         givens = [OrderedDict() for d in self._datasets]
         updates = [OrderedDict() for d in self._datasets]
         for i, channel in enumerate(self.channels.values()):

--- a/pylearn2/tests/test_monitor.py
+++ b/pylearn2/tests/test_monitor.py
@@ -134,6 +134,31 @@ def test_counting():
     assert isinstance(model.monitor.get_examples_seen(), py_integer_types)
     assert isinstance(model.monitor.get_batches_seen(), py_integer_types)
 
+def test_large_examples():
+    BATCH_SIZE = 10000
+    num_examples = 60002994
+    NUM_FEATURES = 3
+
+    model = DummyModel(NUM_FEATURES)
+    monitor = Monitor.get_monitor(model)
+
+    monitoring_dataset = DummyDataset(num_examples = num_examples,
+            num_features = NUM_FEATURES)
+
+    monitor.add_dataset(monitoring_dataset, 'sequential', batch_size=BATCH_SIZE)
+
+    name = 'z'
+
+    monitor.add_channel(name = name,
+            ipt = model.input_space.make_theano_batch(),
+            val = 0.,
+            data_specs=(model.get_input_space(), model.get_input_source()))
+
+    try:
+        monitor()
+    except RuntimeError:
+        assert False
+
 def test_reject_empty():
 
     # Test that Monitor raises an error if asked to iterate over 0 batches


### PR DESCRIPTION
1. Add corruptor in DeepComposedAutoencoder, for implementing deep denoising autoencoder
2. Fix #1356 