### PR TITLE
fixes #1445

### DIFF
--- a/pylearn2/linear/local_c01b.py
+++ b/pylearn2/linear/local_c01b.py
@@ -58,7 +58,8 @@ class Local(LinearTransform, LocalDot):
         """TODO: Local ignores partial_sum argument,
                  figure out how James' code controls it"""
 
-        logger.warning("partial_sum argument ignored")
+        if partial_sum is not None:
+            logger.warning("partial_sum argument ignored")
 
         LocalDot.__init__(self,
             filters=filters,

--- a/pylearn2/models/maxout.py
+++ b/pylearn2/models/maxout.py
@@ -1086,6 +1086,7 @@ class MaxoutLocalC01B(Layer):
                  kernel_stride=(1, 1)):
 
         assert (pool_shape is None) == (pool_stride is None)
+        super(MaxoutLocalC01B, self).__init__()
 
         detector_channels = num_channels * num_pieces
 


### PR DESCRIPTION
missing constructor in MaxoutLocalC01B
only show warning if partial_sum is used

```bash
$ THEANO_FLAGS='device=cpu' theano-nose pylearn2/linear/local_c01b.py

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
$ THEANO_FLAGS='device=cpu' theano-nose pylearn2/models/maxout.py

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
```
