### PR TITLE
fix inconsistency of arguments in the constructor of RNN

### DIFF
--- a/pylearn2/sandbox/rnn/models/rnn.py
+++ b/pylearn2/sandbox/rnn/models/rnn.py
@@ -44,9 +44,10 @@ class RNN(MLP):
                  layer_name=None, **kwargs):
         input_source = self.add_mask_source(input_space, input_source)
         self.use_monitoring_channels = kwargs.pop('use_monitoring_channels', 0)
-        super(RNN, self).__init__(layers, batch_size, input_space,
-                                  input_source, nvis, seed, layer_name,
-                                  **kwargs)
+        super(RNN, self).__init__(layers=layers, batch_size=batch_size,
+                                  input_space=input_space,
+                                  input_source=input_source, nvis=nvis,
+                                  seed=seed, layer_name=layer_name, **kwargs)
         self.theano_rng = make_theano_rng(int(self.rng.randint(2 ** 30)),
                                           which_method=["normal", "uniform"])
 


### PR DESCRIPTION
The super class of `RNN` is `MLP`. The order of parameter list of the constructor of `MLP` is:

```python
def __init__(self, layers, batch_size=None, input_space=None,
             input_source='features', target_source='targets',
             nvis=None, seed=None, layer_name=None, monitor_targets=True,
             **kwargs):
```

But in the constructor of `RNN`, `super`'s constructor is called with arguments like:

```python
super(RNN, self).__init__(layers, batch_size, input_space,
                          input_source, nvis, seed, layer_name,
                          **kwargs)
```

, which means `target_source=nvis`. 
This PR  fixes it by keyword arguments.