### PR TITLE
Enable monitoring for single model.

### DIFF
--- a/pylearn2/scripts/print_monitor_cv.py
+++ b/pylearn2/scripts/print_monitor_cv.py
@@ -35,6 +35,8 @@ def main(models, all=False):
     values = {}
     for filename in np.atleast_1d(models):
         this_models = serial.load(filename)
+        if not isinstance(this_models, list):
+          this_models = [this_models]
         for model in list(this_models):
             monitor = model.monitor
             channels = monitor.channels


### PR DESCRIPTION
When I tried tutorial, the following error occured.

```
$ print_monitor_cv.py cifar_grbm_smd.pkl
Traceback (most recent call last):
  File "XXXXXXX/pylearn2/pylearn2/scripts/print_monitor_cv.py", line 84, in <module>
    main(**vars(args))
  File "XXXXXXX/pylearn2/pylearn2/scripts/print_monitor_cv.py", line 38, in main
    for model in list(this_models):
TypeError: 'GaussianBinaryRBM' object is not iterable
```

The print_monitor_cv.py seems not to support single layer model, so I patched it.
It would be nice if you could adopt this patch.
