### PR TITLE
Fix for #1172

### DIFF
--- a/pylearn2/devtools/nan_guard.py
+++ b/pylearn2/devtools/nan_guard.py
@@ -12,6 +12,7 @@ import logging
 from theano.compile import Mode
 import theano
 import theano.tensor as T
+from theano.sandbox.cuda import CudaNdarray
 import numpy as np
 from pylearn2.models.dbm import flatten
 from pylearn2.utils import contains_nan, contains_inf
@@ -37,7 +38,7 @@ class NanGuardMode(Mode):
         If True, raise an error when a value greater than 1e10 is encountered.
     """
     def __init__(self, nan_is_error, inf_is_error, big_is_error=True):
-        self.guard_input = T.vector('nan_guard')
+        self.guard_input = theano.sandbox.cuda.fvector('nan_guard')
         if nan_is_error or inf_is_error:
             self.gpumin = theano.function(
                 [self.guard_input], T.min(self.guard_input),
@@ -75,7 +76,7 @@ class NanGuardMode(Mode):
             error = False
             if nan_is_error:
                 err = False
-                if isinstance(var, theano.sandbox.cuda.CudaNdarray):
+                if isinstance(var, CudaNdarray):
                     err = np.isnan(self.gpumin(var.reshape(var.size)))
                 else:
                     err = contains_nan(var)
@@ -84,7 +85,7 @@ class NanGuardMode(Mode):
                     error = True
             if inf_is_error:
                 err = False
-                if isinstance(var, theano.sandbox.cuda.CudaNdarray):
+                if isinstance(var, CudaNdarray):
                     err = (np.isinf(self.gpumin(var.reshape(var.size))) or \
                            np.isinf(self.gpumax(var.reshape(var.size))))
                 else:
@@ -94,7 +95,7 @@ class NanGuardMode(Mode):
                     error = True
             if big_is_error:
                 err = False
-                if isinstance(var, theano.sandbox.cuda.CudaNdarray):
+                if isinstance(var, CudaNdarray):
                     err = (self.gpuabsmax(var.reshape(var.size)) > 1e10)
                 else:
                     err = (np.abs(var).max() > 1e10)

--- a/pylearn2/devtools/nan_guard.py
+++ b/pylearn2/devtools/nan_guard.py
@@ -11,6 +11,7 @@ __email__ = "pylearn-dev@googlegroups"
 import logging
 from theano.compile import Mode
 import theano
+import theano.tensor as T
 import numpy as np
 from pylearn2.models.dbm import flatten
 from pylearn2.utils import contains_nan, contains_inf
@@ -36,6 +37,23 @@ class NanGuardMode(Mode):
         If True, raise an error when a value greater than 1e10 is encountered.
     """
     def __init__(self, nan_is_error, inf_is_error, big_is_error=True):
+        self.guard_input = T.vector('nan_guard')
+        if nan_is_error or inf_is_error:
+            self.gpumin = theano.function(
+                [self.guard_input], T.min(self.guard_input),
+                mode='FAST_RUN'
+            )
+        if inf_is_error:
+            self.gpumax = theano.function(
+                [self.guard_input], T.max(self.guard_input),
+                mode='FAST_RUN'
+            )
+        if big_is_error:
+            self.gpuabsmax = theano.function(
+                [self.guard_input], T.max(T.abs_(self.guard_input)),
+                mode='FAST_RUN'
+            )
+
         def do_check_on(var, nd, f, is_input):
             """
             Checks `var` for NaNs / Infs. If detected, raises an exception
@@ -56,15 +74,31 @@ class NanGuardMode(Mode):
             """
             error = False
             if nan_is_error:
-                if contains_nan(var):
+                err = False
+                if isinstance(var, theano.sandbox.cuda.CudaNdarray):
+                    err = np.isnan(self.gpumin(var.reshape(var.size)))
+                else:
+                    err = contains_nan(var)
+                if err:
                     logger.error('NaN detected')
                     error = True
             if inf_is_error:
-                if contains_inf(var):
+                err = False
+                if isinstance(var, theano.sandbox.cuda.CudaNdarray):
+                    err = (np.isinf(self.gpumin(var.reshape(var.size))) or \
+                           np.isinf(self.gpumax(var.reshape(var.size))))
+                else:
+                    err = contains_inf(var)
+                if err:
                     logger.error('Inf detected')
                     error = True
             if big_is_error:
-                if np.abs(var).max() > 1e10:
+                err = False
+                if isinstance(var, theano.sandbox.cuda.CudaNdarray):
+                    err = (self.gpuabsmax(var.reshape(var.size)) > 1e10)
+                else:
+                    err = (np.abs(var).max() > 1e10)
+                if err:
                     logger.error('Big value detected')
                     error = True
             if error:

--- a/pylearn2/devtools/nan_guard.py
+++ b/pylearn2/devtools/nan_guard.py
@@ -12,7 +12,7 @@ import logging
 from theano.compile import Mode
 import theano
 import theano.tensor as T
-from theano.sandbox.cuda import CudaNdarray
+import theano.sandbox.cuda as cuda
 import numpy as np
 from pylearn2.models.dbm import flatten
 from pylearn2.utils import contains_nan, contains_inf
@@ -38,22 +38,23 @@ class NanGuardMode(Mode):
         If True, raise an error when a value greater than 1e10 is encountered.
     """
     def __init__(self, nan_is_error, inf_is_error, big_is_error=True):
-        self.guard_input = theano.sandbox.cuda.fvector('nan_guard')
-        if nan_is_error or inf_is_error:
-            self.gpumin = theano.function(
-                [self.guard_input], T.min(self.guard_input),
-                mode='FAST_RUN'
-            )
-        if inf_is_error:
-            self.gpumax = theano.function(
-                [self.guard_input], T.max(self.guard_input),
-                mode='FAST_RUN'
-            )
-        if big_is_error:
-            self.gpuabsmax = theano.function(
-                [self.guard_input], T.max(T.abs_(self.guard_input)),
-                mode='FAST_RUN'
-            )
+        if cuda.cuda_available:
+            self.guard_input = cuda.fvector('nan_guard')
+            if nan_is_error or inf_is_error:
+                self.gpumin = theano.function(
+                    [self.guard_input], T.min(self.guard_input),
+                    mode='FAST_RUN'
+                )
+            if inf_is_error:
+                self.gpumax = theano.function(
+                    [self.guard_input], T.max(self.guard_input),
+                    mode='FAST_RUN'
+                )
+            if big_is_error:
+                self.gpuabsmax = theano.function(
+                    [self.guard_input], T.max(T.abs_(self.guard_input)),
+                    mode='FAST_RUN'
+                )
 
         def do_check_on(var, nd, f, is_input):
             """
@@ -76,7 +77,7 @@ class NanGuardMode(Mode):
             error = False
             if nan_is_error:
                 err = False
-                if isinstance(var, CudaNdarray):
+                if cuda.cuda_available and isinstance(var, cuda.CudaNdarray):
                     err = np.isnan(self.gpumin(var.reshape(var.size)))
                 else:
                     err = contains_nan(var)
@@ -85,7 +86,7 @@ class NanGuardMode(Mode):
                     error = True
             if inf_is_error:
                 err = False
-                if isinstance(var, CudaNdarray):
+                if cuda.cuda_available and isinstance(var, cuda.CudaNdarray):
                     err = (np.isinf(self.gpumin(var.reshape(var.size))) or \
                            np.isinf(self.gpumax(var.reshape(var.size))))
                 else:
@@ -95,7 +96,7 @@ class NanGuardMode(Mode):
                     error = True
             if big_is_error:
                 err = False
-                if isinstance(var, CudaNdarray):
+                if cuda.cuda_available and isinstance(var, cuda.CudaNdarray):
                     err = (self.gpuabsmax(var.reshape(var.size)) > 1e10)
                 else:
                     err = (np.abs(var).max() > 1e10)

--- a/pylearn2/devtools/tests/test_nan_guard.py
+++ b/pylearn2/devtools/tests/test_nan_guard.py
@@ -5,6 +5,11 @@ import theano.tensor as T
 
 
 def test_NanGuardMode():
+    """
+    Tests if NanGuardMode is working by feeding in numpy.inf and numpy.nans
+    intentionally. A working implementation should be able to capture all
+    the abnormalties.
+    """
     x = T.matrix()
     w = theano.shared(numpy.random.randn(5, 7).astype(theano.config.floatX))
     y = T.dot(x, w)

--- a/pylearn2/devtools/tests/test_nan_guard.py
+++ b/pylearn2/devtools/tests/test_nan_guard.py
@@ -1,3 +1,6 @@
+"""
+This test is for testing the NanGuardMode.
+"""
 from pylearn2.devtools.nan_guard import NanGuardMode
 import numpy
 import theano
@@ -42,5 +45,5 @@ def test_NanGuardMode():
     except AssertionError:
         work[2] = True
 
-    if not reduce(lambda x, y: x and y, work):
+    if not (work[0] and work[1] and work[2]):
         raise AssertionError("NanGuardMode not working.")

--- a/pylearn2/devtools/tests/test_nan_guard.py
+++ b/pylearn2/devtools/tests/test_nan_guard.py
@@ -1,0 +1,41 @@
+from pylearn2.devtools.nan_guard import NanGuardMode
+import numpy
+import theano
+import theano.tensor as T
+
+
+def test_NanGuardMode():
+    x = T.matrix()
+    w = theano.shared(numpy.random.randn(5, 7).astype(theano.config.floatX))
+    y = T.dot(x, w)
+
+    fun = theano.function(
+        [x], y,
+        mode=NanGuardMode(nan_is_error=True, inf_is_error=True)
+    )
+    a = numpy.random.randn(3, 5).astype(theano.config.floatX)
+    infa = numpy.tile(
+        (numpy.asarray(100.) ** 1000000).astype(theano.config.floatX), (3, 5))
+    nana = numpy.tile(
+        numpy.asarray(numpy.nan).astype(theano.config.floatX), (3, 5))
+    biga = numpy.tile(
+        numpy.asarray(1e20).astype(theano.config.floatX), (3, 5))
+
+    work = [False, False, False]
+
+    fun(a)  # normal values
+    try:
+        fun(infa)  # INFs
+    except AssertionError:
+        work[0] = True
+    try:
+        fun(nana)  # NANs
+    except AssertionError:
+        work[1] = True
+    try:
+        fun(biga)  # big values
+    except AssertionError:
+        work[2] = True
+    
+    if not reduce(lambda x, y: x and y, work):
+        raise AssertionError("NanGuardMode not working.")

--- a/pylearn2/devtools/tests/test_nan_guard.py
+++ b/pylearn2/devtools/tests/test_nan_guard.py
@@ -36,6 +36,6 @@ def test_NanGuardMode():
         fun(biga)  # big values
     except AssertionError:
         work[2] = True
-    
+
     if not reduce(lambda x, y: x and y, work):
         raise AssertionError("NanGuardMode not working.")

--- a/pylearn2/termination_criteria/__init__.py
+++ b/pylearn2/termination_criteria/__init__.py
@@ -221,16 +221,16 @@ class EpochCounter(TerminationCriterion):
         if self._new_epochs:
             self._epochs_done = 0
         else:
-            # epochs_seen = 1 on first continue_learning() call
-            self._epochs_done = model.monitor.get_epochs_seen() - 1
+            self._epochs_done = model.monitor.get_epochs_seen()
 
     @functools.wraps(TerminationCriterion.continue_learning)
     def continue_learning(self, model):
         if not hasattr(self, "_epochs_done"):
             self.initialize(model)
 
+        old_epochs_done = self._epochs_done
         self._epochs_done += 1
-        return self._epochs_done < self._max_epochs
+        return old_epochs_done < self._max_epochs
 
 
 class And(TerminationCriterion):

--- a/pylearn2/termination_criteria/tests/test_init.py
+++ b/pylearn2/termination_criteria/tests/test_init.py
@@ -18,10 +18,7 @@ def test_epoch_counter():
     """
     Test epoch counter with max_epochs={True,False}
     """
-
-    N = 5
-
-    def produce_train_obj(new_epochs, model=None):
+    def produce_train_obj(new_epochs, max_epochs, model=None):
         if model is None:
             model = MLP(layers=[Softmax(layer_name='y',
                                         n_classes=2,
@@ -34,7 +31,7 @@ def test_epoch_counter():
         dataset = DenseDesignMatrix(X=np.random.normal(size=(6, 3)),
                                     y=np.random.normal(size=(6, 2)))
 
-        epoch_counter = EpochCounter(max_epochs=N,
+        epoch_counter = EpochCounter(max_epochs=max_epochs,
                                      new_epochs=new_epochs)
 
         algorithm = SGD(batch_size=2, learning_rate=0.1,
@@ -48,21 +45,41 @@ def test_epoch_counter():
         assert epochs_seen == n, \
             "%d epochs seen and should be %d" % (epochs_seen, n)
 
-    # Tests for N new epochs
-    train_obj = produce_train_obj(new_epochs=True)
+    # Tests for 5 new epochs
+    train_obj = produce_train_obj(new_epochs=True, max_epochs=5)
     train_obj.main_loop()
-    test_epochs(train_obj.model.monitor.get_epochs_seen(), N)
-    train_obj = produce_train_obj(new_epochs=True, model=train_obj.model)
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), 5)
+    train_obj = produce_train_obj(new_epochs=True, max_epochs=5,
+                                  model=train_obj.model)
     train_obj.main_loop()
-    test_epochs(train_obj.model.monitor.get_epochs_seen(), 2 * N)
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), 2 * 5)
 
-    # Tests for N max epochs
-    train_obj = produce_train_obj(new_epochs=False)
+    # Tests for 5 max epochs
+    train_obj = produce_train_obj(new_epochs=False, max_epochs=5)
     train_obj.main_loop()
-    test_epochs(train_obj.model.monitor.get_epochs_seen(), N)
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), 5)
 
-    # Try training while already reached max_epochs, should stop after 1 epoch
-    # on first continue_learning() call
-    train_obj = produce_train_obj(new_epochs=False, model=train_obj.model)
+
+    # Tests for 0 new epochs
+    train_obj = produce_train_obj(new_epochs=True, max_epochs=0)
+    before_train = train_obj.model.get_weights()
     train_obj.main_loop()
-    test_epochs(train_obj.model.monitor.get_epochs_seen(), N+1)
+    after_train = train_obj.model.get_weights()
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), 0)
+    assert np.all(before_train == after_train)
+
+    train_obj = produce_train_obj(new_epochs=True, max_epochs=0,
+                                  model=train_obj.model)
+    before_train = train_obj.model.get_weights()
+    train_obj.main_loop()
+    after_train = train_obj.model.get_weights()
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), 0)
+    assert np.all(before_train == after_train)
+
+    # Tests for 0 max epochs
+    train_obj = produce_train_obj(new_epochs=False, max_epochs=0)
+    before_train = train_obj.model.get_weights()
+    train_obj.main_loop()
+    after_train = train_obj.model.get_weights()
+    test_epochs(train_obj.model.monitor.get_epochs_seen(), 0)
+    assert np.all(before_train == after_train)

--- a/pylearn2/termination_criteria/tests/test_init.py
+++ b/pylearn2/termination_criteria/tests/test_init.py
@@ -59,7 +59,6 @@ def test_epoch_counter():
     train_obj.main_loop()
     test_epochs(train_obj.model.monitor.get_epochs_seen(), 5)
 
-
     # Tests for 0 new epochs
     train_obj = produce_train_obj(new_epochs=True, max_epochs=0)
     before_train = train_obj.model.get_weights()

--- a/pylearn2/train.py
+++ b/pylearn2/train.py
@@ -140,26 +140,34 @@ class Train(object):
         t0 = datetime.now()
         self.setup()
         if self.algorithm is None:
-            self.run_callbacks_and_monitoring()
-            while True:
-                if self.exceeded_time_budget(t0, time_budget):
-                    break
+            extension_continue = self.run_callbacks_and_monitoring()
+            # First check if the model is already beyond the stop criteria of
+            # training, if so, just return directly.
+            continue_learning = (self.model.continue_learning() and
+                                 extension_continue)
+            assert continue_learning in [True, False, 0, 1]
+            if continue_learning:
+                while True:
+                    if self.exceeded_time_budget(t0, time_budget):
+                        break
 
-                rval = self.model.train_all(dataset=self.dataset)
-                if rval is not None:
-                    raise ValueError("Model.train_all should not return " +
-                                     "anything. Use Model.continue_learning " +
-                                     "to control whether learning continues.")
-                self.model.monitor.report_epoch()
-                extension_continue = self.run_callbacks_and_monitoring()
-                freq = self.save_freq
-                if freq > 0 and self.model.monitor.get_epochs_seen() % freq == 0:
-                    self.save()
-                continue_learning = (self.model.continue_learning() and
-                                     extension_continue)
-                assert continue_learning in [True, False, 0, 1]
-                if not continue_learning:
-                    break
+                    rval = self.model.train_all(dataset=self.dataset)
+                    if rval is not None:
+                        raise ValueError(
+                            "Model.train_all should not return anything. Use "
+                            "Model.continue_learning to control whether "
+                            "learning continues.")
+                    self.model.monitor.report_epoch()
+                    extension_continue = self.run_callbacks_and_monitoring()
+                    freq = self.save_freq
+                    if freq > 0 and \
+                        self.model.monitor.get_epochs_seen() % freq == 0:
+                        self.save()
+                    continue_learning = (self.model.continue_learning() and
+                                         extension_continue)
+                    assert continue_learning in [True, False, 0, 1]
+                    if not continue_learning:
+                        break
         else:
             if not hasattr(self.model, 'monitor'):
                 # TODO: is this really necessary? I just put this error here
@@ -193,36 +201,47 @@ already been reported."""
                     val=self.total_seconds,
                     data_specs=(NullSpace(), ''),
                     dataset=self.model.monitor._datasets[0])
-            self.run_callbacks_and_monitoring()
+            extension_continue = self.run_callbacks_and_monitoring()
 
-            while True:
-                if self.exceeded_time_budget(t0, time_budget):
-                    break
+            # First check if the model is already beyond the stop criteria of
+            # training, if so, just return directly.
+            continue_learning = (
+                self.algorithm.continue_learning(self.model) and
+                extension_continue
+            )
+            assert continue_learning in [True, False, 0, 1]
+            if continue_learning:
+                while True:
+                    if self.exceeded_time_budget(t0, time_budget):
+                        break
 
-                with log_timing(log, None, level=logging.DEBUG,
-                                callbacks=[self.total_seconds.set_value]):
-                    with log_timing(
+                    with log_timing(log, None, level=logging.DEBUG,
+                                    callbacks=[self.total_seconds.set_value]):
+                        with log_timing(
                             log, None, final_msg='Time this epoch:',
-                            callbacks=[self.training_seconds.set_value]):
-                        rval = self.algorithm.train(dataset=self.dataset)
-                    if rval is not None:
-                        raise ValueError("TrainingAlgorithm.train should not "
-                                         "return anything. Use "
-                                         "TrainingAlgorithm.continue_learning "
-                                         "to control whether learning "
-                                         "continues.")
-                    self.model.monitor.report_epoch()
-                    extension_continue = self.run_callbacks_and_monitoring()
-                    if self.save_freq > 0 and \
-                       self.model.monitor.get_epochs_seen() % self.save_freq == 0:
-                        self.save()
-                continue_learning = (
-                    self.algorithm.continue_learning(self.model) and
-                    extension_continue
-                )
-                assert continue_learning in [True, False, 0, 1]
-                if not continue_learning:
-                    break
+                            callbacks=[self.training_seconds.set_value]
+                        ):
+                            rval = self.algorithm.train(dataset=self.dataset)
+                        if rval is not None:
+                            raise ValueError(
+                                "TrainingAlgorithm.train should not return "
+                                "anything. Use "
+                                "TrainingAlgorithm.continue_learning to "
+                                "control whether learning continues."
+                            )
+                        self.model.monitor.report_epoch()
+                        extension_continue = self.run_callbacks_and_monitoring()
+                        if self.save_freq > 0 and \
+                            self.model.monitor.get_epochs_seen() % \
+                            self.save_freq == 0:
+                            self.save()
+                    continue_learning = (
+                        self.algorithm.continue_learning(self.model) and
+                        extension_continue
+                    )
+                    assert continue_learning in [True, False, 0, 1]
+                    if not continue_learning:
+                        break
 
         self.model.monitor.training_succeeded = True
 

--- a/pylearn2/train_extensions/tests/test_roc_auc.py
+++ b/pylearn2/train_extensions/tests/test_roc_auc.py
@@ -62,7 +62,7 @@ test_yaml = """
                     max_epochs: 1,
                 },
                 !obj:pylearn2.termination_criteria.MonitorBased {
-                    channel_name: train_y_roc_auc,
+                    channel_name: train_roc_auc,
                     prop_decrease: 0.,
                     N: 1,
                 },
@@ -112,7 +112,7 @@ test_yaml_ovr = """
                     max_epochs: 1,
                 },
                 !obj:pylearn2.termination_criteria.MonitorBased {
-                    channel_name: train_y_roc_auc,
+                    channel_name: train_roc_auc-0vX,
                     prop_decrease: 0.,
                     N: 1,
                 },
@@ -173,7 +173,7 @@ test_yaml_ovo = """
                     max_epochs: 1,
                 },
                 !obj:pylearn2.termination_criteria.MonitorBased {
-                    channel_name: train_y_roc_auc,
+                    channel_name: train_roc_auc-0v1,
                     prop_decrease: 0.,
                     N: 1,
                 },


### PR DESCRIPTION
Test for the presence of 'np.nan', 'np.inf', and bigmnumbers larger than 1e10, using a theano function which finds the minimum/maximun of the theano.sandbox.cuda.CudaNdarray and then transfers the reduced result onto CPU. This implementaion avoids massive data transfer between GPU and CPU when the CudaNdarray is very large, at the expense of compiling an extra theano function at the instantiation of NanGuardMode.

While using CPU, it does exactly the same to its initial version.
