### PR TITLE
Raising a `RuntimeError` when NaN is found during training

### DIFF
--- a/pylearn2/training_algorithms/sgd.py
+++ b/pylearn2/training_algorithms/sgd.py
@@ -418,7 +418,7 @@ class SGD(TrainingAlgorithm):
         for param in self.params:
             value = param.get_value(borrow=True)
             if not isfinite(value):
-                raise Exception("NaN in " + param.name)
+                raise RuntimeError("NaN in " + param.name)
 
         self.first = False
         rng = self.rng
@@ -467,7 +467,7 @@ class SGD(TrainingAlgorithm):
         for param in self.params:
             value = param.get_value(borrow=True)
             if not isfinite(value):
-                raise Exception("NaN in " + param.name)
+                raise RuntimeError("NaN in " + param.name)
 
     def continue_learning(self, model):
         """


### PR DESCRIPTION
When using PyLearn2 from another python library, I've found it would be easier to have specific exceptions to deal with common problems during training (e.g. NaN in SGD).

This PR will raise a `RuntimeError` instead of an exception when training results in NaN. This makes it easier to catch problems and fits a little better with the official Python exception classifications.