### PR TITLE
AdaGrad accepts zero-filled params - fixes #1499, #1496

### DIFF
--- a/pylearn2/training_algorithms/tests/test_learning_rule.py
+++ b/pylearn2/training_algorithms/tests/test_learning_rule.py
@@ -3,6 +3,7 @@ import numpy as np
 from theano.compat.six.moves import zip as izip
 
 from pylearn2.costs.cost import SumOfCosts
+from pylearn2.datasets.dense_design_matrix import DenseDesignMatrix
 from pylearn2.testing.cost import SumOfOneHalfParamsSquared
 from pylearn2.testing.cost import SumOfParams
 from pylearn2.testing.datasets import ArangeDataset
@@ -143,7 +144,6 @@ def test_adadelta():
         state[param]['dx2'] = np.zeros(param_shape)
 
     def adadelta_manual(model, state):
-        inc = []
         rval = []
         for scale, param in izip(scales, model.get_params()):
             pstate = state[param]
@@ -170,23 +170,34 @@ def test_adadelta():
                izip(manual, model.get_params()))
 
 
-def test_adagrad():
+def prepare_adagrad_test(dataset_type='arrange', model_type='random'):
     """
-    Make sure that learning_rule.AdaGrad obtains the same parameter values as
-    with a hand-crafted AdaGrad implementation, given a dummy model and
-    learning rate scaler for each parameter.
+    Factor out common code for AdaGrad tests.
 
-    Reference:
-    "Adaptive subgradient methods for online learning and
-    stochastic optimization", Duchi J, Hazan E, Singer Y.
+    Parameters
+    ----------
+    dataset_type : string, optional
+        Can use either `arrange` to use an ArangeDataset instance or
+        `zeros` to create an all-zeros DenseDesignMatrix.
+    model_type : string, optional
+        How to initialize the model; `random` will initialize parameters
+        to random values, `zeros` to zero.
+
     """
-
     # We include a cost other than SumOfParams so that data is actually
     # queried from the training set, and the expected number of updates
     # are applied.
     cost = SumOfCosts([SumOfOneHalfParamsSquared(), (0., DummyCost())])
-    model = DummyModel(shapes, lr_scalers=scales)
-    dataset = ArangeDataset(1)
+    model = DummyModel(shapes, lr_scalers=scales, init_type=model_type)
+    if dataset_type == 'arrange':
+        dataset = ArangeDataset(1)
+    elif dataset_type == 'zeros':
+        X = np.zeros((1, 1))
+        X[:, 0] = np.arange(1)
+        dataset = DenseDesignMatrix(X)
+    else:
+        raise ValueError('Unknown value for dataset_type: %s',
+                         dataset_type)
 
     sgd = SGD(cost=cost,
               learning_rate=learning_rate,
@@ -200,6 +211,21 @@ def test_adagrad():
         param_shape = param.get_value().shape
         state[param] = {}
         state[param]['sg2'] = np.zeros(param_shape)
+
+    return (cost, model, dataset, sgd, state)
+
+def test_adagrad():
+    """
+    Make sure that learning_rule.AdaGrad obtains the same parameter values as
+    with a hand-crafted AdaGrad implementation, given a dummy model and
+    learning rate scaler for each parameter.
+
+    Reference:
+    "Adaptive subgradient methods for online learning and
+    stochastic optimization", Duchi J, Hazan E, Singer Y.
+    """
+
+    cost, model, dataset, sgd, state = prepare_adagrad_test()
 
     def adagrad_manual(model, state):
         rval = []
@@ -226,6 +252,35 @@ def test_adagrad():
                for manual_param, sgd_param in
                izip(manual, model.get_params()))
 
+def test_adagard_max_scaling():
+    """
+    Tests the max_scaling argument to the constructor.
+
+    One corner case that prompted the insertion of this parameter is when
+    the weights are all-zeros (see #1496).
+    """
+
+    # the value must be positive
+    try:
+        AdaGrad(-1.0)
+        allows_null = True
+    except AssertionError:
+        allows_null = False
+    assert not allows_null
+
+    # should not generate RuntimeError and/or generate NaNs
+    def one_case(dataset_type, model_type):
+        # prepare a test bed
+        cost, model, dataset, sgd, state = prepare_adagrad_test(dataset_type,
+                                                                model_type)
+        # SGD will also throw RuntimeError if it finds NaNs
+        sgd.train(dataset=dataset)
+        for param in model.get_params():
+            assert not np.any(np.isnan(param.get_value()))
+    one_case('zeros', 'zeros')
+    one_case('arrange', 'zeros')
+    one_case('zeros', 'random')
+    one_case('arrange', 'random')
 
 def test_rmsprop():
     """
@@ -262,7 +317,6 @@ def test_rmsprop():
         state[param]['g2'] = np.zeros(param_shape)
 
     def rmsprop_manual(model, state):
-        inc = []
         rval = []
         epsilon = 1. / max_scaling
         for scale, param in izip(scales, model.get_params()):

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -50,10 +50,28 @@ class DummyCost(DefaultDataSpecsMixin, Cost):
 
 
 class DummyModel(Model):
+    """
+    A dummy model used for testing.
 
-    def __init__(self, shapes, lr_scalers=None):
+    Parameters
+    ----------
+    shapes : list
+        List of shapes for each parameter.
+    lr_scalers : list, optional
+        Scalers to use for each parameter.
+    init_type : string, optional
+        How to fill initial values in parameters: `random` - generate random
+        values; `zeros` - set all to zeros.
+    """
+    def __init__(self, shapes, lr_scalers=None, init_type='random'):
         super(DummyModel, self).__init__()
-        self._params = [sharedX(np.random.random(shape)) for shape in shapes]
+        if init_type == 'random':
+            self._params = [sharedX(np.random.random(shape)) for shape in shapes]
+        elif init_type == 'zeros':
+            self._params = [sharedX(np.zeros(shape)) for shape in shapes]
+        else:
+            raise ValueError('Unknown value for init_type: %s',
+                             init_type)
         self.input_space = VectorSpace(1)
         self.lr_scalers = lr_scalers
 


### PR DESCRIPTION
Also enhances `DummyModel` to initialize the parameters to either zeros or random values.
`test_adagrad()` is modified to allow for a factored-out initialization of the test that is then reused in `test_adagard_max_scaling()`.