### PR TITLE
AdaGrad accepts zero-filled params - fixes #1499, #1496

### DIFF
--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -50,10 +50,28 @@ class DummyCost(DefaultDataSpecsMixin, Cost):
 
 
 class DummyModel(Model):
+    """
+    A dummy model used for testing.
 
-    def __init__(self, shapes, lr_scalers=None):
+    Parameters
+    ----------
+    shapes : list
+        List of shapes for each parameter.
+    lr_scalers : list, optional
+        Scalers to use for each parameter.
+    init_type : string, optional
+        How to fill initial values in parameters: `random` - generate random
+        values; `zeros` - set all to zeros.
+    """
+    def __init__(self, shapes, lr_scalers=None, init_type='random'):
         super(DummyModel, self).__init__()
-        self._params = [sharedX(np.random.random(shape)) for shape in shapes]
+        if init_type == 'random':
+            self._params = [sharedX(np.random.random(shp)) for shp in shapes]
+        elif init_type == 'zeros':
+            self._params = [sharedX(np.zeros(shp)) for shp in shapes]
+        else:
+            raise ValueError('Unknown value for init_type: %s',
+                             init_type)
         self.input_space = VectorSpace(1)
         self.lr_scalers = lr_scalers
 


### PR DESCRIPTION
Also enhances `DummyModel` to initialize the parameters to either zeros or random values.
`test_adagrad()` is modified to allow for a factored-out initialization of the test that is then reused in `test_adagard_max_scaling()`.