### PR TITLE
LinearGaussian.cost_matrix

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -3916,6 +3916,10 @@ class LinearGaussian(Linear):
         return (0.5 * T.dot(T.sqr(Y - Y_hat), self.beta).mean() -
                 0.5 * T.log(self.beta).sum())
 
+    @wraps(Linear.cost_matrix)
+    def cost_matrix(self, Y, Y_hat):
+        return 0.5 * T.sqr(Y - Y_hat) * self.beta - 0.5 * T.log(self.beta)
+
     @wraps(Layer._modify_updates)
     def _modify_updates(self, updates):
 


### PR DESCRIPTION
This fixes a bug where LinearGaussian overrides `cost` but not `cost_matrix`. This means that the value you get from `cost` is not consistent with the value you get from `cost_from_cost_matrix`.