### PR TITLE
Fix yaml files in scripts/papers/maxout

### DIFF
--- a/pylearn2/scripts/papers/maxout/cifar10.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10.yaml
@@ -5,7 +5,6 @@
             axes: ['c', 0, 1, 'b']
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -72,12 +71,11 @@
         },
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        batch_size: 128,
         learning_rate: .17,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: .5
             },
-        train_iteration_mode: 'even_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
         monitoring_dataset:
             {
                 'test' : &valid !obj:pylearn2.datasets.zca_dataset.ZCA_Dataset {

--- a/pylearn2/scripts/papers/maxout/cifar10.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10.yaml
@@ -104,7 +104,7 @@
             decay_factor: .01
         },
         !obj:pylearn2.train_extensions.window_flip.WindowAndFlip {
-            pad_randomized: 8,
+            pad_randomized: 4,
             window_shape: *window_shape,
             randomize: [ *train],
             center: [ *valid ]

--- a/pylearn2/scripts/papers/maxout/cifar10_no_aug.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10_no_aug.yaml
@@ -5,7 +5,6 @@
             axes: ['c', 0, 1, 'b']
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -72,12 +71,11 @@
         }
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        batch_size: 128,
         learning_rate: .17,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: .5
             },
-        train_iteration_mode: 'even_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
         monitoring_dataset:
             {
                 'test' : &valid !obj:pylearn2.datasets.zca_dataset.ZCA_Dataset {

--- a/pylearn2/scripts/papers/maxout/cifar10_no_aug_valid.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10_no_aug_valid.yaml
@@ -7,7 +7,6 @@
             axes: ['c', 0, 1, 'b']
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -74,12 +73,11 @@
         }
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        batch_size: 128,
         learning_rate: .17,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: .5
             },
-        train_iteration_mode: 'even_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
         monitoring_dataset:
             {
                 'valid' : &valid !obj:pylearn2.datasets.zca_dataset.ZCA_Dataset {

--- a/pylearn2/scripts/papers/maxout/cifar10_old_small.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10_old_small.yaml
@@ -7,7 +7,6 @@
         axes: ['c', 0, 1, 'b']
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -72,12 +71,11 @@
         },
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        batch_size: 128,
         learning_rate: .1,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: 0.5,
         },
-        train_iteration_mode: 'even_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
         monitoring_dataset:
             {
                 'valid' : !obj:pylearn2.datasets.zca_dataset.ZCA_Dataset {

--- a/pylearn2/scripts/papers/maxout/cifar10_valid.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10_valid.yaml
@@ -113,7 +113,7 @@
             decay_factor: .01
         },
         !obj:pylearn2.train_extensions.window_flip.WindowAndFlip {
-            pad_randomized: 8,
+            pad_randomized: 4,
             window_shape: *window_shape,
             randomize: [ *train],
             center: [ *valid ]

--- a/pylearn2/scripts/papers/maxout/cifar10_valid.yaml
+++ b/pylearn2/scripts/papers/maxout/cifar10_valid.yaml
@@ -7,7 +7,6 @@
             axes: ['c', 0, 1, 'b']
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -74,11 +73,10 @@
         },
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        batch_size: 128,
         learning_rate: .17,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: .5 },
-        train_iteration_mode: 'even_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
         monitoring_dataset:
             {
                 'valid' : &valid !obj:pylearn2.datasets.zca_dataset.ZCA_Dataset {

--- a/pylearn2/scripts/papers/maxout/mnist.yaml
+++ b/pylearn2/scripts/papers/maxout/mnist.yaml
@@ -6,7 +6,6 @@
         stop: 50000
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -55,12 +54,11 @@
         },
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
+        batch_size: 128,
         learning_rate: .05,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: .5,
         },
-        train_iteration_mode: 'even_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
         monitoring_dataset:
             {
                 'valid' : !obj:pylearn2.datasets.mnist.MNIST {

--- a/pylearn2/scripts/papers/maxout/svhn.yaml
+++ b/pylearn2/scripts/papers/maxout/svhn.yaml
@@ -5,7 +5,6 @@
         axes: ['c', 0, 1, 'b']
     },
     model: !obj:pylearn2.models.mlp.MLP {
-        batch_size: 128,
         layers: [
                  !obj:pylearn2.models.maxout.MaxoutConvC01B {
                      layer_name: 'h0',
@@ -70,8 +69,8 @@
         },
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
-        train_iteration_mode: 'even_batchwise_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
+        batch_size: 128,
+        train_iteration_mode: 'batchwise_shuffled_sequential',
         learning_rate: 0.200000,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: 0.5,

--- a/pylearn2/scripts/papers/maxout/svhn2.yaml
+++ b/pylearn2/scripts/papers/maxout/svhn2.yaml
@@ -9,8 +9,8 @@
         name: "old_monitor"
     },
     algorithm: !obj:pylearn2.training_algorithms.sgd.SGD {
-        train_iteration_mode: 'even_batchwise_shuffled_sequential',
-        monitor_iteration_mode: 'even_sequential',
+        batch_size: 128,
+        train_iteration_mode: 'batchwise_shuffled_sequential',
         learning_rate: 0.008600,
         learning_rule: !obj:pylearn2.training_algorithms.learning_rule.Momentum {
             init_momentum: 0.900000,


### PR DESCRIPTION
- changed models to not require fixed batch, remove use of forced even iterators
- fix padding size in cifar scripts with data augmentation

This should address the problems reported in https://groups.google.com/d/topic/pylearn-dev/geKKzmQ1QbM/discussion