### PR TITLE
Remove obsolete __maintain__ statements

### DIFF
--- a/pylearn2/cross_validation/__init__.py
+++ b/pylearn2/cross_validation/__init__.py
@@ -11,7 +11,6 @@ monitor channel values for the collection of saved models.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 from copy import deepcopy
 import os

--- a/pylearn2/cross_validation/blocks.py
+++ b/pylearn2/cross_validation/blocks.py
@@ -5,7 +5,6 @@ Cross-validation with blocks.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 from theano.compat.six.moves import xrange
 from pylearn2.blocks import StackedBlocks

--- a/pylearn2/cross_validation/dataset_iterators.py
+++ b/pylearn2/cross_validation/dataset_iterators.py
@@ -5,7 +5,6 @@ Cross-validation dataset iterators.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 import numpy as np
 import warnings

--- a/pylearn2/cross_validation/mlp.py
+++ b/pylearn2/cross_validation/mlp.py
@@ -5,7 +5,6 @@ Cross-validation with MLPs.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 from pylearn2.models.mlp import Layer, PretrainedLayer
 

--- a/pylearn2/cross_validation/subset_iterators.py
+++ b/pylearn2/cross_validation/subset_iterators.py
@@ -10,7 +10,6 @@ subset into a train/valid split.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 import numpy as np
 import warnings

--- a/pylearn2/cross_validation/train_cv_extensions.py
+++ b/pylearn2/cross_validation/train_cv_extensions.py
@@ -5,7 +5,6 @@ Cross-validation training extensions.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 import numpy as np
 import os

--- a/pylearn2/datasets/hdf5_deprecated.py
+++ b/pylearn2/datasets/hdf5_deprecated.py
@@ -5,7 +5,6 @@ Objects for datasets serialized in HDF5 format (.h5).
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 try:
     import h5py

--- a/pylearn2/scripts/print_monitor_cv.py
+++ b/pylearn2/scripts/print_monitor_cv.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 import argparse
 from collections import Iterable

--- a/pylearn2/train_extensions/roc_auc.py
+++ b/pylearn2/train_extensions/roc_auc.py
@@ -6,7 +6,6 @@ dataset(s), reported via monitor channels.
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "3-clause BSD"
-__maintainer__ = "Steven Kearnes"
 
 import numpy as np
 try:


### PR DESCRIPTION
I am no longer an active developer of pylearn2 and would like to remove my name as a maintainer of these files.