### PR TITLE
Remove RNNWrapper as metaclass for MLP

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -65,8 +65,6 @@ from pylearn2.expr.nnet import (elemwise_kl, kl, compute_precision,
 from pylearn2.costs.mlp import L1WeightDecay as _L1WD
 from pylearn2.costs.mlp import WeightDecay as _WD
 
-from pylearn2.sandbox.rnn.models.mlp_hook import RNNWrapper
-
 
 logger = logging.getLogger(__name__)
 
@@ -86,13 +84,8 @@ logger.debug("MLP changing the recursion limit.")
 # precisely when you're going to exceed the stack segment.
 sys.setrecursionlimit(40000)
 
-if six.PY3:
-    LayerBase = six.with_metaclass(RNNWrapper, Model)
-else:
-    LayerBase = Model
 
-
-class Layer(LayerBase):
+class Layer(Model):
 
     """
     Abstract class. A Layer of an MLP.
@@ -112,9 +105,6 @@ class Layer(LayerBase):
     Block interface were upgraded to be that flexible, then we could make this
     a block.
     """
-    # This enables RNN compatibility
-    __metaclass__ = RNNWrapper
-
     # When applying dropout to a layer's input, use this for masked values.
     # Usually this will be 0, but certain kinds of layers may want to override
     # this behaviour.

--- a/pylearn2/sandbox/rnn/models/tests/test_rnn.py
+++ b/pylearn2/sandbox/rnn/models/tests/test_rnn.py
@@ -1,6 +1,9 @@
 """
 Unit tests for the RNN model
+
+Disabled because RNNWrapper is no longer a metaclass for MLP.
 """
+from nose.plugins.skip import SkipTest
 import unittest
 
 import numpy as np
@@ -22,6 +25,12 @@ class TestRNNs(unittest.TestCase):
     ----------
     None
     """
+    def setUp(self):
+        """
+        Skip all tests.
+        """
+        raise SkipTest('Sandbox RNNs are disabled.')
+
     def test_fprop(self):
         """
         Use an RNN without non-linearity to create the Mersenne numbers


### PR DESCRIPTION
This was seemingly causing trouble for some layers.