### PR TITLE
fix bug: while the task of csv dataset is classification

### DIFF
--- a/pylearn2/datasets/csv_dataset.py
+++ b/pylearn2/datasets/csv_dataset.py
@@ -125,6 +125,7 @@ class CSVDataset(DenseDesignMatrix):
         if self.task == 'regression':
             super(CSVDataset, self).__init__(X=X, y=y, **kwargs)
         else:
+            y = y.astype('int64')
             super(CSVDataset, self).__init__(X=X, y=y,
                                              y_labels=np.max(y) + 1, **kwargs)
 


### PR DESCRIPTION
fix bug: while the task of csv dataset is classification, y is still float, so there is exception arise:

Traceback (most recent call last):
  File "/home/junbo.chenjb/Backup/eclipse-kepler/plugins/org.python.pydev_2.8.1.2013072611/pysrc/pydevd.py", line 1445, in <module>
    debugger.run(setup['file'], None, None)
  File "/home/junbo.chenjb/Backup/eclipse-kepler/plugins/org.python.pydev_2.8.1.2013072611/pysrc/pydevd.py", line 1091, in run
    pydev_imports.execfile(file, globals, locals) #execute the script
  File "/home/junbo.chenjb/workspace/pylearn2_ext/tools/simple_train.py", line 15, in <module>
    train.main_loop()
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/train.py", line 201, in main_loop
    extension_continue = self.run_callbacks_and_monitoring()
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/train.py", line 255, in run_callbacks_and_monitoring
    self.model.monitor()
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/monitor.py", line 254, in __call__
    for X in myiterator:
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/utils/iteration.py", line 984, in next
    rval = self._fallback_next(next_index)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/utils/iteration.py", line 1002, in _fallback_next
    for data, fn in safe_izip(self._raw_data, self._convert)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/utils/iteration.py", line 1002, in <genexpr>
    for data, fn in safe_izip(self._raw_data, self._convert)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/utils/iteration.py", line 952, in <lambda>
    dspace.np_format_as(batch, sp))
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/space/__init__.py", line 486, in np_format_as
    space=space)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/space/__init__.py", line 541, in _format_as
    self._validate(is_numeric, batch)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/space/__init__.py", line 726, in _validate
    self._validate_impl(is_numeric, batch)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/space/__init__.py", line 1096, in _validate_impl
    super(IndexSpace, self)._validate_impl(is_numeric, batch)
  File "/home/junbo.chenjb/libs/pylearn2/pylearn2/space/__init__.py", line 905, in _validate_impl
    (batch.dtype, self.dtype))
TypeError: Cannot safely cast batch dtype float64 to space's dtype int64. 