### PR TITLE
Corrected a bug leading to infinite loops with flat objectives

### DIFF
--- a/pylearn2/optimization/batch_gradient_descent.py
+++ b/pylearn2/optimization/batch_gradient_descent.py
@@ -350,9 +350,10 @@ class BatchGradientDescent(object):
                     if self.verbose:
                         logger.info('\t{0} {1}'.format(alpha, obj))
 
-                    # Use <= rather than = so if there are ties
-                    # the bigger step size wins
-                    if obj <= best_obj:
+                    # Should not use <= instead of < because, for a flat
+                    # objective, this leads to an infinite loop due to the
+                    # condition used to grow the step sizes
+                    if obj < best_obj:
                         best_obj = obj
                         best_alpha = alpha
                         best_alpha_ind = ind
@@ -374,7 +375,8 @@ class BatchGradientDescent(object):
                     alpha_list = [alpha / 3. for alpha in alpha_list]
                     if self.verbose:
                         logger.info('shrinking the step size')
-                elif best_alpha_ind > len(alpha_list) - 2:
+                elif best_alpha_ind >= len(alpha_list) - 1:
+                    # Grow the step size if the last step size was used
                     alpha_list = [alpha * 2. for alpha in alpha_list]
                     if self.verbose:
                         logger.info('growing the step size')


### PR DESCRIPTION
As reported in issue #1508 , the use of '<=' operator to determine the best step size in combination with the rule used to grow the step sizes across iterations leads to an infinite loop when the objective function is flat along the descent direction:

1. The condition [line 347](https://github.com/lisa-lab/pylearn2/blob/master/pylearn2/optimization/batch_gradient_descent.py#L347) leads to select the greatest step size for equal objective values:

    ```python
                for ind, alpha in enumerate(alpha_list):
                    self._goto_alpha(alpha)
                    obj = self.obj(*inputs)
                    if self.verbose:
                        logger.info('\t{0} {1}'.format(alpha, obj))

                    # Use <= rather than = so if there are ties
                    # the bigger step size wins
                    if obj <= best_obj:
                        best_obj = obj
                        best_alpha = alpha
                        best_alpha_ind = ind
    ```
2.  The condition [line 377](https://github.com/lisa-lab/pylearn2/blob/master/pylearn2/optimization/batch_gradient_descent.py#L377) leads to grow the list of tested step sizes whenever the best selected step size was the last in the list:

    ```python
                elif best_alpha_ind > len(alpha_list) - 2:
                    alpha_list = [alpha * 2. for alpha in alpha_list]
                    if self.verbose:
                        logger.info('growing the step size')
    ```
Obviously when the function remains unchanged, the step sizes will grow indefinitely. Issue #1508 shows a simple sample code that triggers the bug.

Two changes are proposed:

1. change '<=' to '<'
2. rewrite the condition for growing step sizes to make it clearer that we check whether the last step size was used.