### PR TITLE
Allow specifying cross-validation subsets of the dataset to be monitored

### DIFF
--- a/pylearn2/cross_validation/__init__.py
+++ b/pylearn2/cross_validation/__init__.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Cross validation module.
 
 Each fold of cross validation is a separate experiment, so we create a
@@ -34,6 +34,8 @@ class TrainCV(object):
         Training model. If list, training model for each fold.
     algorithm : TrainingAlgorithm
         Training algorithm.
+    algorithm_monitoring_datasets : list or None
+        Subsets of the dataset to be monitored. Leave as None to monitor all subsets.
     save_path : str or None
         Output filename for trained models. Also used (with modification)
         for individual models if save_folds is True.
@@ -48,7 +50,7 @@ class TrainCV(object):
     cv_extensions : list or None
         TrainCVExtension objects for the parent TrainCV object.
     """
-    def __init__(self, dataset_iterator, model, algorithm=None,
+    def __init__(self, dataset_iterator, model, algorithm=None, algorithm_monitoring_datasets=None,
                  save_path=None, save_freq=0, extensions=None,
                  allow_overwrite=True, save_folds=False, cv_extensions=None):
         self.dataset_iterator = dataset_iterator
@@ -76,7 +78,11 @@ class TrainCV(object):
 
             # setup monitoring datasets
             this_algorithm = deepcopy(algorithm)
-            this_algorithm._set_monitoring_dataset(datasets)
+            if algorithm_monitoring_datasets is None:
+                monitoring_datasets = datasets
+            else:
+                monitoring_datasets = {k:v for (k,v) in datasets.items() if k in algorithm_monitoring_datasets}
+            this_algorithm._set_monitoring_dataset(monitoring_datasets)
 
             # extensions
             this_extensions = deepcopy(extensions)


### PR DESCRIPTION
This adds the ability to specify which subsets of the dataset (e.g. 'valid' and 'test' only) are to be monitored when training under cross-validation, reducing the training time when the dataset is large.