### PR TITLE
Fix broken imports of downsample.max_pool_2d

### DIFF
--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -21,7 +21,7 @@ from theano.gof.op import get_debug_values
 from theano.sandbox.cuda import cuda_enabled
 from theano.sandbox.cuda.dnn import dnn_available, dnn_pool
 from theano.sandbox.rng_mrg import MRG_RandomStreams
-from theano.tensor.signal.downsample import max_pool_2d
+from theano.tensor.signal.pool import pool_2d
 import theano.tensor as T
 
 from pylearn2.compat import OrderedDict
@@ -3517,7 +3517,7 @@ def max_pool(bc01, pool_shape, pool_stride, image_shape, try_dnn=True):
         use_dnn = False
 
     if pool_shape == pool_stride and not use_dnn:
-        mx = max_pool_2d(bc01, pool_shape, False)
+        mx = pool_2d(bc01, pool_shape, False)
         mx.name = 'max_pool(' + name + ')'
         return mx
 

--- a/pylearn2/scripts/icml_2013_wrepl/multimodal/extract_kmeans_features.py
+++ b/pylearn2/scripts/icml_2013_wrepl/multimodal/extract_kmeans_features.py
@@ -62,7 +62,7 @@ bc01 = X.dimshuffle('x', 2, 0, 1)
 Z = T.nnet.conv2d(input=bc01, filters=kernels, subsample = (means.shape[1] / 2, means.shape[2] /2),
         filter_shape = kernels.get_value().shape)
 
-F = T.signal.downsample.max_pool_2d(Z, (2, 2))
+F = T.signal.pool.pool_2d(Z, (2, 2))
 
 F = T.clip(F - .5, 0., 10.)
 


### PR DESCRIPTION
The module theano.tensor.signal.downsample was removed in Theano, and downsample.max_pool_2d was moved to pool.pool_2d.

https://github.com/Theano/Theano/commit/1960ddab6cb681ab75f714f0d0215a0e725c9ef3

https://github.com/Theano/Theano/commit/372939b1512eadf32bfe3c3aa38b3e4faf9dd792