### PR TITLE
Make cuda-convnet wrapper compatible to recent Theano

### DIFF
--- a/pylearn2/sandbox/cuda_convnet/base_acts.py
+++ b/pylearn2/sandbox/cuda_convnet/base_acts.py
@@ -147,12 +147,11 @@ class BaseActs(GpuOp):
         return hash(tuple(msg))
 
     # Make sure the cuda_convnet library is compiled and up-to-date
-    def make_thunk(self, node, storage_map, compute_map, no_recycling):
+    def make_thunk(self, *args, **kwargs):
         if not convnet_available():
             raise RuntimeError('Could not compile cuda_convnet')
 
-        return super(BaseActs, self).make_thunk(node, storage_map,
-                                                compute_map, no_recycling)
+        return super(BaseActs, self).make_thunk(*args, **kwargs)
 
 # This is needed as otherwise DebugMode will consider that
 # BaseActs.make_thunk do something else then the default code, and

--- a/pylearn2/sandbox/cuda_convnet/pool.py
+++ b/pylearn2/sandbox/cuda_convnet/pool.py
@@ -324,7 +324,7 @@ class MaxPool(GpuOp):
         return [MaxPoolGrad(self.ds, self.stride, self.start)(x, maxout, gz)]
 
     # Make sure the cuda_convnet library is compiled and up-to-date
-    def make_thunk(self, node, storage_map, compute_map, no_recycling):
+    def make_thunk(self, *args, **kwargs):
         """
         .. todo::
 
@@ -333,8 +333,7 @@ class MaxPool(GpuOp):
         if not convnet_available():
             raise RuntimeError('Could not compile cuda_convnet')
 
-        return super(MaxPool, self).make_thunk(
-                node, storage_map, compute_map, no_recycling)
+        return super(MaxPool, self).make_thunk(*args, **kwargs)
 
 
 class MaxPoolRop(GpuOp):

--- a/pylearn2/sandbox/cuda_convnet/probabilistic_max_pooling.py
+++ b/pylearn2/sandbox/cuda_convnet/probabilistic_max_pooling.py
@@ -394,7 +394,7 @@ class ProbMaxPool(GpuOp):
         return ProbMaxPoolGrad(self.ds, self.stride, self.start)(p, h, gp, gh, gp_iszero, gh_iszero)
 
     # Make sure the cuda_convnet library is compiled and up-to-date
-    def make_thunk(self, node, storage_map, compute_map, no_recycling):
+    def make_thunk(self, *args, **kwargs):
         """
         .. todo::
 
@@ -403,8 +403,7 @@ class ProbMaxPool(GpuOp):
         if not convnet_available():
             raise RuntimeError('Could not compile cuda_convnet')
 
-        return super(ProbMaxPool, self).make_thunk(
-                node, storage_map, compute_map, no_recycling)
+        return super(ProbMaxPool, self).make_thunk(*args, **kwargs)
 
 class ProbMaxPoolGrad(GpuOp):
     """

--- a/pylearn2/sandbox/cuda_convnet/stochastic_pool.py
+++ b/pylearn2/sandbox/cuda_convnet/stochastic_pool.py
@@ -329,7 +329,7 @@ class StochasticMaxPool(GpuOp):
         return [MaxPoolGrad(self.ds, self.stride, self.start)(x, maxout, gz), zeros_like(seed)]
 
     # Make sure the cuda_convnet library is compiled and up-to-date
-    def make_thunk(self, node, storage_map, compute_map, no_recycling):
+    def make_thunk(self, *args, **kwargs):
         """
         .. todo::
 
@@ -338,8 +338,7 @@ class StochasticMaxPool(GpuOp):
         if not convnet_available():
             raise RuntimeError('Could not compile cuda_convnet')
 
-        return super(StochasticMaxPool, self).make_thunk(
-                node, storage_map, compute_map, no_recycling)
+        return super(StochasticMaxPool, self).make_thunk(*args, **kwargs)
 
 class WeightedMaxPool(GpuOp):
     """


### PR DESCRIPTION
The cuda-convnet wrapper uses `make_thunk` to check if cuda-convnet is available. https://github.com/Theano/Theano/pull/5073 changed the `make_thunk` signature to include an `impl` parameter. This PR changes all `make_thunk` calls to pass on `*args` and `**kwargs` so it is compatible to all versions of Theano. (Theano also has a `prepare_node` method which would be suitable for this check, but I'm not sure if this would work with older Theano versions then.)