### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pylearn2/datasets/cache.py
+++ b/pylearn2/datasets/cache.py
@@ -57,7 +57,7 @@ class LocalDatasetCache:
 
     def cache_file(self, filename):
         """
-        Caches a file locally if possible. If caching was succesfull, or if
+        Caches a file locally if possible. If caching was successful, or if
         the file was previously successfully cached, this method returns the
         path to the local copy of the file. If not, it returns the path to
         the original file.

--- a/pylearn2/datasets/svhn.py
+++ b/pylearn2/datasets/svhn.py
@@ -369,7 +369,7 @@ class SVHN_On_Memory(dense_design_matrix.DenseDesignMatrix):
         rng = make_np_rng(None, 322, which_method="shuffle")
 
         def design_matrix_view(data_x):
-            """reshape data_x to deisng matrix view
+            """reshape data_x to design matrix view
             """
             data_x = numpy.transpose(data_x, axes=[3, 2, 0, 1])
             data_x = data_x.reshape((data_x.shape[0], 32 * 32 * 3))

--- a/pylearn2/models/gsn.py
+++ b/pylearn2/models/gsn.py
@@ -254,7 +254,7 @@ class GSN(StackedBlocks, Model):
             A time step consists of a call to the _update function
             (so updating both the even and odd layers). When there is no
             walkback, the GSN runs long enough for signal from the bottom
-            layer to propogate to the top layer and then back to the bottom.
+            layer to propagate to the top layer and then back to the bottom.
             The walkback parameter adds single steps on top of the default.
         """
         # the indices which are being set
@@ -288,7 +288,7 @@ class GSN(StackedBlocks, Model):
 
         self._set_activations(minibatch)
 
-        # intialize steps
+        # initialize steps
         steps = [self.activations[:]]
 
         self.apply_postact_corruption(self.activations,

--- a/pylearn2/models/mlp.py
+++ b/pylearn2/models/mlp.py
@@ -198,7 +198,7 @@ class Layer(Model):
         Y_hat : theano.gof.Variable
             The predictions.
             Assumed to be the output of the layer's `fprop` method.
-            The implmentation is permitted to do things like look at the
+            The implementation is permitted to do things like look at the
             ancestors of `Y_hat` in the theano graph. This is useful for
             e.g. computing numerically stable *log* probabilities when
             `Y_hat` is the *probability*.

--- a/pylearn2/packaged_dependencies/theano_linear/spconv.py
+++ b/pylearn2/packaged_dependencies/theano_linear/spconv.py
@@ -605,7 +605,7 @@ def applySparseFilter(kerns, kshp, nkern, images, imgshp, step=(1,1), bias=None,
     Output feature map will have shape
     `batch_size x number of kernels * output_size`.
 
-    Each filter is applied seperately to consecutive output pixels.
+    Each filter is applied separately to consecutive output pixels.
 
     Parameters
     ----------

--- a/pylearn2/sandbox/cuda_convnet/cutil.h
+++ b/pylearn2/sandbox/cuda_convnet/cutil.h
@@ -836,7 +836,7 @@ extern "C" {
         exit(EXIT_FAILURE);                                                  \
     } } while(0);
 
-    //! Check if conditon is true (flexible assert)
+    //! Check if condition is true (flexible assert)
 #  define CUT_CONDITION( val)                                                \
     if( CUTFalse == cutCheckCondition( val, __FILE__, __LINE__)) {           \
         exit(EXIT_FAILURE);                                                  \

--- a/pylearn2/sandbox/cuda_convnet/cutil_inline_runtime.h
+++ b/pylearn2/sandbox/cuda_convnet/cutil_inline_runtime.h
@@ -239,7 +239,7 @@ inline int cutGetMaxGflopsGraphicsDeviceId()
 		char *fmt2		= (char*)malloc(fmt2_sz);
 		va_list  vlist;
 		va_start(vlist, fmt);
-		while((_vsnprintf(fmt2, fmt2_sz, fmt, vlist)) < 0) // means there wasn't anough room
+		while((_vsnprintf(fmt2, fmt2_sz, fmt, vlist)) < 0) // means there wasn't enough room
 		{
 			fmt2_sz *= 2;
 			if(fmt2) free(fmt2);

--- a/pylearn2/space/tests/test_space.py
+++ b/pylearn2/space/tests/test_space.py
@@ -193,7 +193,7 @@ def test_np_format_as_composite_composite():
 
     def make_composite_space(image_space):
         """
-        Returns a compsite space with a particular tree structure.
+        Returns a composite space with a particular tree structure.
         """
         return CompositeSpace((CompositeSpace((image_space,) * 2),
                                VectorSpace(dim=1)))

--- a/pylearn2/training_algorithms/tests/test_sgd.py
+++ b/pylearn2/training_algorithms/tests/test_sgd.py
@@ -1777,7 +1777,7 @@ def test_batch_size_specialization():
 
 def test_empty_monitoring_datasets():
     """
-    Test that handling of monitoring datasets dictionnary
+    Test that handling of monitoring datasets dictionary
     does not fail when it is empty.
     """
 

--- a/pylearn2/utils/iteration.py
+++ b/pylearn2/utils/iteration.py
@@ -305,7 +305,7 @@ class ForcedEvenIterator(SubsetIterator):
         Raises
         ------
         StopException
-            When _base_iterator reachs the end of the dataset
+            When _base_iterator reaches the end of the dataset
 
         Notes
         -----


### PR DESCRIPTION
There are small typos in:
- pylearn2/datasets/cache.py
- pylearn2/datasets/svhn.py
- pylearn2/models/gsn.py
- pylearn2/models/mlp.py
- pylearn2/packaged_dependencies/theano_linear/spconv.py
- pylearn2/sandbox/cuda_convnet/cutil.h
- pylearn2/sandbox/cuda_convnet/cutil_inline_runtime.h
- pylearn2/space/tests/test_space.py
- pylearn2/training_algorithms/tests/test_sgd.py
- pylearn2/utils/iteration.py

Fixes:
- Should read `successful` rather than `succesfull`.
- Should read `separately` rather than `seperately`.
- Should read `reaches` rather than `reachs`.
- Should read `propagate` rather than `propogate`.
- Should read `initialize` rather than `intialize`.
- Should read `implementation` rather than `implmentation`.
- Should read `enough` rather than `anough`.
- Should read `dictionary` rather than `dictionnary`.
- Should read `design` rather than `deisng`.
- Should read `condition` rather than `conditon`.
- Should read `composite` rather than `compsite`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md